### PR TITLE
remove '--toggle Help message' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ Available Commands:
 Flags:
   -h, --help        help for dtmate
   -n, --nonewline   do not output a newline character
-  -t, --toggle      Help message for toggle
   -v, --version     version for dtmate
 
 Use "dtmate [command] --help" for more information about a command.

--- a/cmd/dtmate/cmd/root.go
+++ b/cmd/dtmate/cmd/root.go
@@ -45,7 +45,6 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	rootCmd.PersistentFlags().BoolVarP(&optRootNoNewline, "nonewline", "n", false, "do not output a newline character")
 	versionTemplate := fmt.Sprintf("dtmate version %s\n%s\n", DateTimeMate.ModVersion, DateTimeMate.ModUrl)
 	rootCmd.SetVersionTemplate(versionTemplate)


### PR DESCRIPTION
This was a cobra default which is unneeded.
