### PR TITLE
Improve conv command internals and tests

### DIFF
--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -7,9 +7,32 @@ import (
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.1.0"
+	ModVersion string = "1.1.1"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
+
+var abbrevMap = [][]string{
+	{"nanoseconds", "ns"},
+	{"microseconds", "us"},
+	{"milliseconds", "ms"},
+	{"seconds", "s"},
+	{"minutes", "m"},
+	{"hours", "h"},
+	{"days", "D"},
+	{"weeks", "W"},
+	{"months", "M"},
+	{"years", "Y"},
+	{"nanosecond", "ns"},
+	{"microsecond", "us"},
+	{"millisecond", "ms"},
+	{"second", "s"},
+	{"minute", "m"},
+	{"hour", "h"},
+	{"day", "D"},
+	{"week", "W"},
+	{"month", "M"},
+	{"year", "Y"},
+}
 
 // convertRelativeDateToActual converts "yesterday", "today", "tomorrow"
 // into actual dates; yesterday and tomorrow are -/+ 24 hours of current time
@@ -30,31 +53,16 @@ func convertRelativeDateToActual(from string) string {
 // shrinkPeriod convert a period into a brief period
 // only allow one replacement per each period
 // Ex: 1 hour 2 minutes 3 seconds => 1h2m3s
-// FIXME: almost redundant code for plural & singular -- try to fix with strings.NewReplacer
 func shrinkPeriod(period string) string {
-	// plural
-	period = strings.Replace(period, "nanoseconds", "ns", 1)
-	period = strings.Replace(period, "microseconds", "us", 1)
-	period = strings.Replace(period, "milliseconds", "ms", 1)
-	period = strings.Replace(period, "seconds", "s", 1)
-	period = strings.Replace(period, "minutes", "m", 1)
-	period = strings.Replace(period, "hours", "h", 1)
-	period = strings.Replace(period, "days", "D", 1)
-	period = strings.Replace(period, "weeks", "W", 1)
-	period = strings.Replace(period, "months", "M", 1)
-	period = strings.Replace(period, "years", "Y", 1)
-
-	// singular
-	period = strings.Replace(period, "nanosecond", "ns", 1)
-	period = strings.Replace(period, "microsecond", "us", 1)
-	period = strings.Replace(period, "millisecond", "ms", 1)
-	period = strings.Replace(period, "second", "s", 1)
-	period = strings.Replace(period, "minute", "m", 1)
-	period = strings.Replace(period, "hour", "h", 1)
-	period = strings.Replace(period, "day", "D", 1)
-	period = strings.Replace(period, "week", "W", 1)
-	period = strings.Replace(period, "month", "M", 1)
-	period = strings.Replace(period, "year", "Y", 1)
+	for _, tuple := range abbrevMap {
+		period = strings.Replace(period, tuple[0], tuple[1], 1)
+	}
 
 	return strings.ReplaceAll(period, " ", "")
+}
+
+// removeTrailingS convert plural to singular, such as "hours" to "hour"
+// FIXME: This works for English only.
+func removeTrailingS(s string) string {
+	return strings.TrimSuffix(s, "s")
 }

--- a/DateTimeMate_test.go
+++ b/DateTimeMate_test.go
@@ -1,10 +1,9 @@
 package DateTimeMate
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestShrinkPeriod(t *testing.T) {
+	// explicitly define these here as a sanity check vs just iterating through abbrevMap
 	var allLongPeriods = []string{"nanoseconds", "microseconds", "milliseconds", "seconds", "minutes", "hours", "days", "weeks", "months", "years"}
 	var allShortPeriods = []string{"ns", "us", "ms", "s", "m", "h", "D", "W", "M", "Y"}
 
@@ -16,7 +15,7 @@ func TestShrinkPeriod(t *testing.T) {
 	}
 
 	for i, period := range allLongPeriods {
-		period = period[:len(period)-1]
+		period = removeTrailingS(period)
 		shrunk := shrinkPeriod(period)
 		if shrunk != allShortPeriods[i] {
 			t.Errorf("[computed: %v] != [correct: %v]", shrunk, allShortPeriods[i])

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The command-line program, `dtmate` *(along with the golang package)* allows you 
 <summary>4. Convert from one group of date/time units to another</summary>
 
 * convert from seconds to weeks, days, hours, minutes, seconds: `dtmate conv 25771401s WDhms`
-* * 25771401 seconds
-* convert weeks, days, hours, minutes, seconds to just seconds: `dtmate conv 25771401s WDhms`
 * * 42 weeks 4 days 6 hours 43 minutes 21 seconds
+* convert weeks, days, hours, minutes, seconds to just seconds, with brief output format: `dtmate conv "42 weeks 4 days 6 hours 43 minutes 21 seconds" seconds -b`
+* * 25771401s
 </details>
 
 ## Installation

--- a/conv_test.go
+++ b/conv_test.go
@@ -3,6 +3,7 @@ package DateTimeMate
 import "testing"
 
 func testConv(t *testing.T, source, target string, brief bool, correct string) {
+	t.Helper()
 	conv := NewConv(
 		ConvWithSource(source),
 		ConvWithTarget(target),

--- a/diff_test.go
+++ b/diff_test.go
@@ -3,6 +3,7 @@ package DateTimeMate
 import "testing"
 
 func testDiffStartEnd(t *testing.T, start, end string, brief bool, correct string) {
+	t.Helper()
 	diff := NewDiff(
 		DiffWithStart(start),
 		DiffWithEnd(end),

--- a/dur.go
+++ b/dur.go
@@ -269,14 +269,6 @@ func validatePeriod(period string) error {
 	return nil
 }
 
-// removeTrailingS convert plural to singular, such as "hours" to "hour"
-func removeTrailingS(s string) string {
-	if len(s) > 0 && s[len(s)-1] == 's' {
-		return s[:len(s)-1]
-	}
-	return s
-}
-
 // expandPeriod convert a brief style period into a long period
 // only allow one replacement per each period
 // Ex: 1h2m3s => 1 hour 2 minutes 3 seconds

--- a/dur_test.go
+++ b/dur_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func testDurAddSubContains(t *testing.T, from, period, correctAdd, correctSub string) {
+	t.Helper()
 	dur := NewDur(
 		DurWithFrom(from),
 		DurWithDur(period))
@@ -29,6 +30,7 @@ func testDurAddSubContains(t *testing.T, from, period, correctAdd, correctSub st
 }
 
 func testDurAddSubOutputFormat(t *testing.T, from, period, outputFormat, correctAdd, correctSub string) {
+	t.Helper()
 	dur := NewDur(
 		DurWithFrom(from),
 		DurWithDur(period),
@@ -40,7 +42,6 @@ func testDurAddSubOutputFormat(t *testing.T, from, period, outputFormat, correct
 	if !strings.Contains(future[0], correctAdd) {
 		t.Errorf("\n[from: %v]\n[period: %v]\n[computed: %v] does not contain:\n[correct: %v]", from, period, future[0], correctAdd)
 	}
-	return
 
 	past, err := dur.Sub()
 	if err != nil {
@@ -52,6 +53,7 @@ func testDurAddSubOutputFormat(t *testing.T, from, period, outputFormat, correct
 }
 
 func testDurAddSubWithRepeat(t *testing.T, from, period string, correctAdd, correctSub []string, repeat int) {
+	t.Helper()
 	dur := NewDur(
 		DurWithFrom(from),
 		DurWithDur(period),
@@ -78,6 +80,7 @@ func testDurAddSubWithRepeat(t *testing.T, from, period string, correctAdd, corr
 }
 
 func testDurAddUntil(t *testing.T, from, until, periodFuture string, correctAdd []string) {
+	t.Helper()
 	durFuture := NewDur(
 		DurWithFrom(from),
 		DurWithDur(periodFuture),
@@ -96,6 +99,7 @@ func testDurAddUntil(t *testing.T, from, until, periodFuture string, correctAdd 
 }
 
 func testDurSubUntil(t *testing.T, from, until, periodPast string, correctSub []string) {
+	t.Helper()
 	durPast := NewDur(
 		DurWithFrom(from),
 		DurWithDur(periodPast),


### PR DESCRIPTION
* Improved `conv` command internals based in feedback provided by @ccoVeille in [PR #5](https://github.com/jftuga/DateTimeMate/pull/5)
* added `t.Helper()` to internal testing functions
* improved `README.md` Q&A: `Convert from one group of date/time units to another`
* improved `shrinkPeriod()` function
* documented internal `conv` functions
* move and optimize `removeTrailingS()` 

