### PR TITLE
feat: add the -e top-level switch to show examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 # Go workspace file
 go.work
 go.work.sum
+cmd/dtmate/cmd/README.md

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,7 @@ version: 2
 before:
   hooks:
     - go mod tidy
+    - go generate ./...
 
 builds:
   - id: dtmate

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -26,6 +26,7 @@
         <method importPath="bytes" receiver="*Buffer" name="WriteRune" />
         <method importPath="strings" receiver="*Builder" name="WriteByte" />
         <method importPath="github.com/spf13/cobra" receiver="*Command" name="Usage" />
+        <method importPath="github.com/spf13/cobra" receiver="*Command" name="Help" />
       </methods>
     </inspection_tool>
     <inspection_tool class="GoUnusedCallResult" enabled="true" level="WARNING" enabled_by_default="true">

--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.1.1"
+	ModVersion string = "1.2.0"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The command-line program, `dtmate` *(along with the golang package)* allows you 
 ## Installation
 
 * Library: `go get -u github.com/jftuga/DateTimeMate`
-* Command line tool: `go install github.com/jftuga/DateTimeMate/cmd/dtmate@latest`
+* Command line tool: `go install -ldflags="-s -w" github.com/jftuga/DateTimeMate/cmd/dtmate@latest`
 * * Binaries for all platforms are provided in the [releases](https://github.com/jftuga/DateTimeMate/releases) section.
 * Homebrew (MacOS / Linux):
 * * `brew tap jftuga/homebrew-tap; brew update; brew install jftuga/tap/dtmate`
@@ -116,29 +116,39 @@ See also the [example](cmd/example/main.go) program.
 dtmate: output the difference between date, time or duration
 
 Usage:
+  dtmate [flags]
   dtmate [command]
 
 Available Commands:
+  conv        Convert a duration from group of units to another
   diff        Output the difference between two date/times
   dur         Output a date/time when given a starting date/time and duration
   help        Help about any command
 
 Flags:
+  -e, --examples    show command-line examples
   -h, --help        help for dtmate
   -n, --nonewline   do not output a newline character
   -v, --version     version for dtmate
 
 Use "dtmate [command] --help" for more information about a command.
 
+---
+
 Durations:
 years months weeks days
 hours minutes seconds milliseconds microseconds nanoseconds
 example: '1 year 2 months 3 days 4 hours 1 minute 6 seconds'
 
-Brief Durations: (dates are always uppercase, times are always lowercase)
+---
+
+Brief Durations:
+(dates are always uppercase, times are always lowercase)
 Y    M    W    D
 h    m    s    ms    us    ns
 examples: 1Y2M3W4D5h6m7s8ms9us1ns, '1Y 2M 3W 4D 5h 6m 7s 8ms 9us 1ns'
+
+---
 
 Relative Date Shortcuts:
 now
@@ -146,6 +156,14 @@ today (returns same value as now)
 yesterday (exactly 24 hours ahead of the current time)
 tomorrow (exactly 24 hours behind the current time)
 example: dtmate dur today 7h10m -a -u tomorrow
+
+---
+
+Conversions:
+1 year is equal to 365.25 days
+Months are not a unit since their lengths vary between 28 and 31 days
+Separate sub-second brief units with a dot
+example: dtmate conv 4321s123456789ns hms.msusns
 ```
 
 </details>
@@ -163,6 +181,9 @@ example: dtmate dur today 7h10m -a -u tomorrow
 <summary>Show</summary>
 
 ```shell
+
+########################### "dtmate diff" examples ###########################
+
 # difference between two times on the same day
 $ dtmate diff 12:00:00 15:30:45
 3 hours 30 minutes 45 seconds
@@ -213,12 +234,18 @@ $ dtmate diff -i -n
 45 seconds%
 
 # same as above, include newline character
-$ echo 15:16:15,15:17 | dtmate -i
+$ echo 15:16:15,15:17 | dtmate diff -i
 45 seconds
 
 # read from STDIN with start on first line and end on second line
 $ printf "15:16:15\n15:17:20" | dtmate diff -i
 1 minute 5 seconds
+
+# use relative start date with brief output
+$ dtmate diff today 2024-07-07 -b
+3D16h38m47s
+
+########################### "dtmate dur" examples ###########################
 
 # add time
 # can also use "years", "months", "weeks", "days"
@@ -249,13 +276,11 @@ $ dtmate dur today 7h10m -u tomorrow -a
 2024-07-03 21:39:28 -0400 EDT
 2024-07-04 04:49:28 -0400 EDT
 
-# use relative start date with brief output
-$ dtmate diff today 2024-07-07 -b
-3D16h38m47s
-
 # set the output format
 $ dtmate dur "2024-07-01 12:00:00" 1W2D3h4m5s -a -f "%Y%m%d.%H%M%S"
 20240710.150405
+
+########################### "dtmate conv" examples ###########################
 
 # convert from one group of date/time units to another
 $ dtmate conv 25771401s WDhms

--- a/cmd/dtmate/cmd/root.go
+++ b/cmd/dtmate/cmd/root.go
@@ -1,22 +1,32 @@
+//go:generate cp -f ../../../README.md .
 package cmd
 
 import (
+	"embed"
 	"fmt"
 	DateTimeMate "github.com/jftuga/DateTimeMate"
 	"github.com/spf13/cobra"
 	"os"
+	"regexp"
 )
 
 const extendedHelp string = `
+---
+
 Durations:
 years months weeks days
 hours minutes seconds milliseconds microseconds nanoseconds
 example: '1 year 2 months 3 days 4 hours 1 minute 6 seconds'
 
-Brief Durations: (dates are always uppercase, times are always lowercase)
+---
+
+Brief Durations:
+(dates are always uppercase, times are always lowercase)
 Y    M    W    D
 h    m    s    ms    us    ns
 examples: 1Y2M3W4D5h6m7s8ms9us1ns, '1Y 2M 3W 4D 5h 6m 7s 8ms 9us 1ns'
+
+---
 
 Relative Date Shortcuts:
 now
@@ -24,6 +34,8 @@ today (returns same value as now)
 yesterday (exactly 24 hours ahead of the current time)
 tomorrow (exactly 24 hours behind the current time)
 example: dtmate dur today 7h10m -a -u tomorrow
+
+---
 
 Conversions:
 1 year is equal to 365.25 days
@@ -37,9 +49,25 @@ var rootCmd = &cobra.Command{
 	Use:     "dtmate",
 	Short:   "dtmate: output the difference between date, time or duration",
 	Version: DateTimeMate.ModVersion,
+	Run: func(cmd *cobra.Command, args []string) {
+		if optRootShowExamples {
+			ShowExamples()
+			os.Exit(0)
+		}
+
+		// if no arguments are provided and no flags are set, show help
+		if len(args) == 0 && !cmd.Flags().Changed("examples") {
+			cmd.Help()
+		}
+	},
 }
 
 var optRootNoNewline bool
+var optRootShowExamples bool
+var readmeExamplesRegex = regexp.MustCompile(`(?ms)## Command Line Examples.*?shell\n(.*?)` + "```")
+
+//go:embed README.md
+var readmeFS embed.FS
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
@@ -52,8 +80,27 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&optRootNoNewline, "nonewline", "n", false, "do not output a newline character")
+	rootCmd.Flags().BoolVarP(&optRootShowExamples, "examples", "e", false, "show command-line examples")
+
 	versionTemplate := fmt.Sprintf("dtmate version %s\n%s\n", DateTimeMate.ModVersion, DateTimeMate.ModUrl)
 	rootCmd.SetVersionTemplate(versionTemplate)
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 	rootCmd.SetUsageTemplate(rootCmd.UsageTemplate() + extendedHelp)
+}
+
+func extractReadmeExamples(markdown string) string {
+	matches := readmeExamplesRegex.FindStringSubmatch(markdown)
+	if len(matches) == 2 {
+		return matches[1]
+	}
+	return "[Internal Error] Unable to output examples. Check the extractShellCode() function."
+}
+
+func ShowExamples() {
+	readmeContent, err := readmeFS.ReadFile("README.md")
+	if err != nil {
+		fmt.Println("Error reading README:", err)
+		return
+	}
+	fmt.Println(extractReadmeExamples(string(readmeContent)))
 }


### PR DESCRIPTION
* The `-e` option to show examples pulls in the `README.md` into the compiled binary using `go:embed`.
* * By using this approach, a separate copy of the CLI examples do not have to be maintained.
* Improved Usage by separating sections with `---`
* Improved Examples by separating commands with `#### "dtmate command" examples ####`
