### PR TITLE
Allow negative durations in conv cmd

### DIFF
--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.2.2"
+	ModVersion string = "1.2.3"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 

--- a/cmd/dtmate/cmd/conv.go
+++ b/cmd/dtmate/cmd/conv.go
@@ -11,9 +11,10 @@ import (
 var optConvBrief bool
 
 var convCmd = &cobra.Command{
-	Use:   "conv [source duration] [target duration]",
-	Short: "Convert a duration from group of units to another",
-	Args:  cobra.MatchAll(cobra.ExactArgs(2)),
+	Use:                "conv [source duration] [target duration]",
+	Short:              "Convert a duration from group of units to another",
+	Args:               cobra.MatchAll(cobra.ExactArgs(2)),
+	DisableFlagParsing: true, // this allows for negative durations
 	Run: func(cmd *cobra.Command, args []string) {
 		outputConvDuration(args[0], args[1], optConvBrief)
 	},

--- a/conv.go
+++ b/conv.go
@@ -217,6 +217,11 @@ func expandBriefTargetDuration(period string) ([]string, error) {
 //   - error: An error if any step of the conversion process fails.
 func (conv *Conv) ConvertDuration() (string, error) {
 	var err error
+	isNegativeDuration := false
+	if conv.Source[0] == '-' {
+		conv.Source = conv.Source[1:]
+		isNegativeDuration = true
+	}
 	fields := strings.Fields(conv.Source)
 	if len(fields) == 1 {
 		// brief format is being used so convert to long duration format
@@ -244,5 +249,9 @@ func (conv *Conv) ConvertDuration() (string, error) {
 	if conv.Brief {
 		result = shrinkPeriod(result)
 	}
-	return strings.TrimSpace(result), nil
+	result = strings.TrimSpace(result)
+	if isNegativeDuration {
+		result = "-" + result
+	}
+	return result, nil
 }

--- a/conv_test.go
+++ b/conv_test.go
@@ -24,12 +24,24 @@ func TestConvHoursMinutesSeconds(t *testing.T) {
 	target := "days hours minutes seconds"
 	correct := "16 days 2 hours 24 minutes 36 seconds"
 	testConv(t, source, target, false, correct)
+
 	correct = "16D2h24m36s"
+	testConv(t, source, target, true, correct)
+
+	source = "-386 hours 24 minutes 36 seconds"
+	correct = "-16 days 2 hours 24 minutes 36 seconds"
+	testConv(t, source, target, false, correct)
+
+	correct = "-16D2h24m36s"
 	testConv(t, source, target, true, correct)
 
 	source = "2 years 26 weeks 15 days 12 hours 30 minutes 30 seconds"
 	target = "hours minutes seconds"
 	correct = "22272 hours 30 minutes 30 seconds"
+	testConv(t, source, target, false, correct)
+
+	source = "-2 years 26 weeks 15 days 12 hours 30 minutes 30 seconds"
+	correct = "-22272 hours 30 minutes 30 seconds"
 	testConv(t, source, target, false, correct)
 }
 
@@ -39,14 +51,30 @@ func TestConvSeconds(t *testing.T) {
 	target := "days hours minutes seconds"
 	correct := "13 days 21 hours 1 minute 1 second"
 	testConv(t, source, target, false, correct)
+
 	correct = "13D21h1m1s"
+	testConv(t, source, target, true, correct)
+
+	source = "-1198861 seconds"
+	correct = "-13 days 21 hours 1 minute 1 second"
+	testConv(t, source, target, false, correct)
+
+	correct = "-13D21h1m1s"
 	testConv(t, source, target, true, correct)
 
 	source = "2 years 26 weeks 15 days 12 hours 30 minutes 30 seconds"
 	target = "seconds"
 	correct = "80181030 seconds"
 	testConv(t, source, target, false, correct)
+
 	correct = "80181030s"
+	testConv(t, source, target, true, correct)
+
+	source = "-2 years 26 weeks 15 days 12 hours 30 minutes 30 seconds"
+	correct = "-80181030 seconds"
+	testConv(t, source, target, false, correct)
+
+	correct = "-80181030s"
 	testConv(t, source, target, true, correct)
 }
 
@@ -56,7 +84,17 @@ func TestConvMinutes(t *testing.T) {
 	target := "weeks days hours minutes seconds"
 	correct := "1 week 3 days 21 hours 22 minutes 29 seconds"
 	testConv(t, source, target, false, correct)
+
+	source = "-15682 minutes 29 seconds"
+	correct = "-1 week 3 days 21 hours 22 minutes 29 seconds"
+	testConv(t, source, target, false, correct)
+
+	source = "15682 minutes 29 seconds"
 	correct = "1W3D21h22m29s"
+	testConv(t, source, target, true, correct)
+
+	source = "-15682 minutes 29 seconds"
+	correct = "-1W3D21h22m29s"
 	testConv(t, source, target, true, correct)
 }
 
@@ -67,8 +105,17 @@ func TestConvSingular(t *testing.T) {
 	correct := "1 week 1 day 1 hour 1 second 1 millisecond 1 microsecond 1 nanosecond"
 	testConv(t, source, target, false, correct)
 
+	source = "-694801 seconds 1 millisecond 1 microsecond 1 nanosecond"
+	correct = "-1 week 1 day 1 hour 1 second 1 millisecond 1 microsecond 1 nanosecond"
+	testConv(t, source, target, false, correct)
+
+	source = "694801 seconds 1 millisecond 1 microsecond 1 nanosecond"
 	target = "WDhms.msusns"
 	correct = "1W1D1h1s1ms1us1ns"
+	testConv(t, source, target, true, correct)
+
+	source = "-694801 seconds 1 millisecond 1 microsecond 1 nanosecond"
+	correct = "-1W1D1h1s1ms1us1ns"
 	testConv(t, source, target, true, correct)
 }
 
@@ -78,13 +125,33 @@ func TestConvMsUsNs(t *testing.T) {
 	target := "hms.msusns"
 	correct := "1 hour 12 minutes 1 second 123 milliseconds 456 microseconds 788 nanoseconds"
 	testConv(t, source, target, false, correct)
+
+	source = "-4321s123456789ns"
+	correct = "-1 hour 12 minutes 1 second 123 milliseconds 456 microseconds 788 nanoseconds"
+	testConv(t, source, target, false, correct)
+
+	source = "4321s123456789ns"
 	correct = "1h12m1s123ms456us788ns"
+	testConv(t, source, target, true, correct)
+
+	source = "-4321s123456789ns"
+	correct = "-1h12m1s123ms456us788ns"
 	testConv(t, source, target, true, correct)
 
 	source = "4321s001001001ns"
 	correct = "1 hour 12 minutes 1 second 1 millisecond 1 microsecond 1 nanosecond"
 	testConv(t, source, target, false, correct)
+
+	source = "-4321s001001001ns"
+	correct = "-1 hour 12 minutes 1 second 1 millisecond 1 microsecond 1 nanosecond"
+	testConv(t, source, target, false, correct)
+
+	source = "4321s001001001ns"
 	correct = "1h12m1s1ms1us1ns"
+	testConv(t, source, target, true, correct)
+
+	source = "-4321s001001001ns"
+	correct = "-1h12m1s1ms1us1ns"
 	testConv(t, source, target, true, correct)
 }
 
@@ -94,16 +161,16 @@ func TestConvNanoseconds1(t *testing.T) {
 	target := "YWDhms.msusns"
 	correct := "39 years 6 weeks 2 days 5 hours 31 minutes 30 seconds 987 milliseconds 654 microseconds 447 nanoseconds"
 	testConv(t, source, target, false, correct)
+
+	source = "-1234567890987654321ns"
+	correct = "-39 years 6 weeks 2 days 5 hours 31 minutes 30 seconds 987 milliseconds 654 microseconds 447 nanoseconds"
+	testConv(t, source, target, false, correct)
+
+	source = "1234567890987654321ns"
 	correct = "39Y6W2D5h31m30s987ms654us447ns"
 	testConv(t, source, target, true, correct)
-}
 
-func TestConvNanoseconds2(t *testing.T) {
-	t.Parallel()
-	source := "1234567890987654321ns"
-	target := "YWDhms.msusns"
-	correct := "39 years 6 weeks 2 days 5 hours 31 minutes 30 seconds 987 milliseconds 654 microseconds 447 nanoseconds"
-	testConv(t, source, target, false, correct)
-	correct = "39Y6W2D5h31m30s987ms654us447ns"
+	source = "-1234567890987654321ns"
+	correct = "-39Y6W2D5h31m30s987ms654us447ns"
 	testConv(t, source, target, true, correct)
 }


### PR DESCRIPTION
Before this patch, this error would occur when trying to use a negative duration:

```shell
$ dtmate conv "-2 hours 3 minutes 4 seconds" ms
Error: unknown shorthand flag: '2' in -2 hours 3 minutes 4 seconds
```

With this patch:

```shell
$ dtmate conv "-2 hours 3 minutes 4 seconds" ms
-123 minutes 4 seconds
```

**Testing**
* `conv_test.go` has been updated to include many `negative duration` tests 
