### PR TITLE
let fmt convert to/from unix (epoch) time

### DIFF
--- a/DateTimeMate_test.go
+++ b/DateTimeMate_test.go
@@ -61,4 +61,19 @@ func TestFormatCommand(t *testing.T) {
 	fmt = "%Z %z"
 	correct = "EDT -0400"
 	testFormat(t, source, fmt, correct)
+
+	source = "2024-11-16 14:01:02"
+	fmt = "%s"
+	correct = "1731783662"
+	testFormat(t, source, fmt, correct)
+
+	source = "1704085262"
+	fmt = "%F %T"
+	correct = "2024-01-01 00:01:02"
+	testFormat(t, source, fmt, correct)
+
+	source = "1704085262999"
+	fmt = "%F %T"
+	correct = "2024-01-01 00:01:02"
+	testFormat(t, source, fmt, correct)
 }

--- a/README.md
+++ b/README.md
@@ -345,6 +345,18 @@ UTC
 
 $ dtmate fmt "Mon Jul 22 08:40:33 EDT 2024" "%Z %z"
 EDT -0400
+
+# convert to unix (epoch) time seconds
+$ dtmate fmt "2024-11-16 14:01:02" "%s"
+1731783662
+
+# from unix (epoch) time seconds
+$ dtmate fmt 1704085262 "%F %T"
+2024-01-01 00:01:02
+
+# also from milliseconds
+$ dtmate fmt 1704085262999 "%F %T"
+2024-01-01 00:01:02
 ```
 </details>
 

--- a/cmd/dtmate/cmd/fmt.go
+++ b/cmd/dtmate/cmd/fmt.go
@@ -1,15 +1,26 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"os"
+
 	"github.com/jftuga/DateTimeMate"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var fmtCmd = &cobra.Command{
 	Use:   "fmt [date/time] [format specifiers]",
 	Short: "reformat a date/time",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if optFmtList {
+			return nil
+		}
+		if len(args) != 2 {
+			return errors.New("requires two arguments: [date/time] [format specifiers]")
+		}
+		return nil
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if optFmtList {
 			listConversionsSpecifiers()
@@ -53,6 +64,7 @@ func listConversionsSpecifiers() {
 		{`%R`, `equivalent to %H:%M`},
 		{`%r`, `equivalent to %I:%M:%S %p`},
 		{`%S`, `the second as a decimal number (00-60)`},
+		{`%s`, `the number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC)`},
 		{`%T`, `equivalent to %H:%M:%S`},
 		{`%t`, `a tab`},
 		{`%U`, `the week number of the year (Sunday as the first day of the week) as a decimal number (00-53)`},


### PR DESCRIPTION
Allows the `fmt` command to convert to & from [unix time](https://en.wikipedia.org/wiki/Unix_time).

```shell
$ dtmate fmt "2024-11-16 14:01:02" "%s"
1731783662

$ dtmate fmt "1704085261" "%F %T"
2024-01-01 00:01:01
```

* Also fixed small problem with `dtmate fmt` and command-line args error checking

@ccoVeille could you please review this PR? I always appreciate your insightful feedback. 😃

