### PR TITLE
add TZ for goreleaser job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,5 +29,6 @@ jobs:
         env:
           HOMEBREW_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TZ: 'America/New_York'
         with:
           args: release --clean


### PR DESCRIPTION
This will attempt to fix `go test`.  Some off the timezone offsets are breaking the tests.
