### PR TITLE
Fix silent overflow in diff for date spans exceeding 291 years

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -81,6 +81,11 @@ func (diff *Diff) CalculateDiff() (string, time.Duration, error) {
 		end = omega.StdTime()
 	}
 
+	yearDiff := end.Year() - start.Year()
+	if yearDiff > 291 || yearDiff < -291 {
+		return "", 0, fmt.Errorf("year difference of %d exceeds 291 year maximum", yearDiff)
+	}
+
 	duration := end.Sub(start)
 	parsed := durafmt.Parse(duration)
 	difference := fmt.Sprintf("%v", parsed)

--- a/diff_test.go
+++ b/diff_test.go
@@ -87,6 +87,17 @@ func TestDiffMilliSeconds(t *testing.T) {
 	testDiffStartEnd(t, start, end, true, correctBrief)
 }
 
+func TestDiffYearOverflow(t *testing.T) {
+	t.Parallel()
+	diff := NewDiff(
+		DiffWithStart("0001-10-19"),
+		DiffWithEnd("2000-10-10"))
+	_, _, err := diff.CalculateDiff()
+	if err == nil {
+		t.Error("expected error for year difference exceeding 291 years")
+	}
+}
+
 func TestDiffRelativeStartEnd(t *testing.T) {
 	t.Parallel()
 	start := "yesterday"


### PR DESCRIPTION
## Summary

- `time.Duration` is an `int64` of nanoseconds, which caps at ~292.27 years. Date diffs exceeding this silently clamp to `MaxInt64`, producing incorrect results (e.g., `diff 0001-10-19 2000-10-10` reported 292 years instead of ~1999 years).
- `CalculateDiff()` now returns an error when the year difference exceeds 291 years.
- Added `TestDiffYearOverflow` to verify the error is returned.

## Test plan

- [x] `go test ./...` passes (new test included)
- [X] Run `dtmate diff 0001-10-19 2000-10-10` and confirm it exits with an error message
- [X] Run `dtmate diff 2000-01-01 2024-06-01` and confirm normal output
