### PR TITLE
Fix TestFormatCommand failing during DST months

### DIFF
--- a/DateTimeMate_test.go
+++ b/DateTimeMate_test.go
@@ -62,9 +62,14 @@ func TestFormatCommand(t *testing.T) {
 	correct = "EDT -0400"
 	testFormat(t, source, fmt, correct)
 
-	source = "2024-11-16 14:01:02"
+	source = "2024-11-16T14:01:02-05:00"
 	fmt = "%s"
 	correct = "1731783662"
+	testFormat(t, source, fmt, correct)
+
+	source = "2024-06-16T14:01:02-04:00"
+	fmt = "%s"
+	correct = "1718560862"
 	testFormat(t, source, fmt, correct)
 
 	source = "1704085262"


### PR DESCRIPTION
## Summary

- `TestFormatCommand` used a bare datetime string (`"2024-11-16 14:01:02"`) for Unix timestamp conversion, making it pass only when the system timezone offset matched the test's expected value (EST/winter).
-  - Running during EDT/summer produced a 3600-second discrepancy.
- `parsetime` silently ignores timezone abbreviations and numeric offsets in space-separated formats.
- - Only ISO 8601 with `T` separator and `-HH:MM` suffix is respected.
- Replaced with explicit ISO 8601 offsets (`-05:00` for EST, `-04:00` for EDT) and added an EDT case to cover both.

## Test plan

- [x] `go test ./...` passes year-round regardless of system DST state
