### PR TITLE
Fix `go install` failure by embedding README.md in the root package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,3 @@
 # Go workspace file
 go.work
 go.work.sum
-
-# Project exclusions
-cmd/dtmate/cmd/README.md

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,6 @@ version: 2
 before:
   hooks:
     - go mod tidy
-    - go generate ./...
     - go test
 
 builds:

--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -1,6 +1,7 @@
 package DateTimeMate
 
 import (
+	_ "embed"
 	"fmt"
 	"strconv"
 	"strings"
@@ -10,6 +11,13 @@ import (
 	"github.com/jftuga/parsetime"
 	"github.com/lestrrat-go/strftime"
 )
+
+// ReadmeMd is the project README, embedded here (next to the file at the
+// module root) because go:embed cannot reference parent directories from
+// the cmd package; the CLI extracts its -e examples from it.
+//
+//go:embed README.md
+var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"

--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -21,7 +21,7 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.4.0"
+	ModVersion string = "1.4.1"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 

--- a/cmd/dtmate/cmd/root.go
+++ b/cmd/dtmate/cmd/root.go
@@ -1,8 +1,6 @@
-//go:generate cp -f ../../../README.md .
 package cmd
 
 import (
-	"embed"
 	"fmt"
 	DateTimeMate "github.com/jftuga/DateTimeMate"
 	"github.com/spf13/cobra"
@@ -66,9 +64,6 @@ var optRootNoNewline bool
 var optRootShowExamples bool
 var readmeExamplesRegex = regexp.MustCompile(`(?ms)## Command Line Examples.*?shell\n(.*?)` + "```")
 
-//go:embed README.md
-var readmeFS embed.FS
-
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
@@ -97,10 +92,5 @@ func extractReadmeExamples(markdown string) string {
 }
 
 func ShowExamples() {
-	readmeContent, err := readmeFS.ReadFile("README.md")
-	if err != nil {
-		fmt.Println("Error reading README:", err)
-		return
-	}
-	fmt.Println(extractReadmeExamples(string(readmeContent)))
+	fmt.Println(extractReadmeExamples(DateTimeMate.ReadmeMd))
 }


### PR DESCRIPTION
## Issue

`go install github.com/jftuga/DateTimeMate/cmd/dtmate@latest` fails to compile:

```
cmd/dtmate/cmd/root.go:69:12: pattern README.md: no matching files found
```

The `cmd` package embedded a copy of `README.md` that was excluded by `.gitignore` and only created locally via a `go:generate` copy step. Since the file was never committed, the module zip published to the Go proxy did not contain it, and `go install` does not run `go generate`. Release binaries were unaffected because goreleaser ran `go generate ./...` before building.

Fixes #27

## Changes

* **`DateTimeMate.go`:** Embed the tracked, module-root `README.md` directly in the root package and expose it as `ReadmeMd`. The embed must live here because `go:embed` cannot reference parent directories from the `cmd` package.
* **`cmd/dtmate/cmd/root.go`:** `ShowExamples()` now reads `DateTimeMate.ReadmeMd`; removed the `go:generate` copy directive, the `embed.FS` variable, and the `embed` import.
* **`.gitignore`:** Removed the `cmd/dtmate/cmd/README.md` exclusion, which is no longer needed.
* **`.goreleaser.yml`:** Removed the `go generate ./...` before-hook, which is no longer needed.
* **Version:** Bumped `ModVersion` to 1.4.1. The v1.4.0 module zip is immutably cached by the Go proxy, so a new tag is required for the fix to reach `@latest` users.

This also eliminates the duplicate-README drift risk: `dtmate -e` output is now always byte-for-byte identical to the committed `README.md`.

## Testing

* `go build ./...`, `go vet ./...`, and all tests pass.
* Reproduced the failure scenario: exported only the git-tracked files (`git archive`, matching what the Go proxy zips) into a clean directory and built there. v1.3.x/v1.4.0 fail this test with the error above; this branch builds successfully and `dtmate -e` prints the examples.
* After tagging v1.4.1, the reporter's exact command can be re-verified: `go install -ldflags="-s -w" github.com/jftuga DateTimeMate/cmd/dtmate@latest`
