### PR TITLE
Add `-n` and `-b` flag support to the `conv` sub-command

### DIFF
--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -21,7 +21,7 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.4.1"
+	ModVersion string = "1.5.0"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 

--- a/cmd/dtmate/cmd/conv.go
+++ b/cmd/dtmate/cmd/conv.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/jftuga/DateTimeMate"
 	"os"
 
@@ -13,16 +15,68 @@ var optConvBrief bool
 var convCmd = &cobra.Command{
 	Use:                "conv [source duration] [target duration]",
 	Short:              "Convert a duration from group of units to another",
-	Args:               cobra.MatchAll(cobra.ExactArgs(2)),
-	DisableFlagParsing: true, // this allows for negative durations
-	Run: func(cmd *cobra.Command, args []string) {
-		outputConvDuration(args[0], args[1], optConvBrief)
+	Args:               cobra.ArbitraryArgs,
+	DisableFlagParsing: true, // this allows for negative durations; flags are parsed manually in RunE
+	RunE: func(cmd *cobra.Command, args []string) error {
+		positional, brief, noNewline, help, err := parseConvArgs(args)
+		if err != nil {
+			return err
+		}
+		if help {
+			return cmd.Help()
+		}
+		if len(positional) != 2 {
+			return fmt.Errorf("accepts 2 arg(s), received %d", len(positional))
+		}
+		optConvBrief = brief
+		if noNewline {
+			optRootNoNewline = true
+		}
+		outputConvDuration(positional[0], positional[1], optConvBrief)
+		return nil
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(convCmd)
 	convCmd.Flags().BoolVarP(&optConvBrief, "brief", "b", false, "output in brief format, such as: 1Y2M3D4h5m6s7ms8us9ns")
+}
+
+// parseConvArgs manually separates flags from positional args because convCmd
+// disables cobra flag parsing to support negative durations; an arg starting
+// with "-" followed by a digit is a negative duration, not a flag
+func parseConvArgs(args []string) (positional []string, brief, noNewline, help bool, err error) {
+	for i, arg := range args {
+		switch {
+		case arg == "--":
+			positional = append(positional, args[i+1:]...)
+			return positional, brief, noNewline, help, nil
+		case arg == "--brief":
+			brief = true
+		case arg == "--nonewline":
+			noNewline = true
+		case arg == "--help":
+			help = true
+		case strings.HasPrefix(arg, "--"):
+			return nil, false, false, false, fmt.Errorf("unknown flag: %s", arg)
+		case len(arg) > 1 && arg[0] == '-' && (arg[1] < '0' || arg[1] > '9'):
+			for _, shorthand := range arg[1:] {
+				switch shorthand {
+				case 'b':
+					brief = true
+				case 'n':
+					noNewline = true
+				case 'h':
+					help = true
+				default:
+					return nil, false, false, false, fmt.Errorf("unknown shorthand flag: %q in %s", shorthand, arg)
+				}
+			}
+		default:
+			positional = append(positional, arg)
+		}
+	}
+	return positional, brief, noNewline, help, nil
 }
 
 func outputConvDuration(source, target string, brief bool) {

--- a/cmd/dtmate/cmd/conv_test.go
+++ b/cmd/dtmate/cmd/conv_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseConvArgs(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		positional []string
+		brief      bool
+		noNewline  bool
+		help       bool
+		wantErr    bool
+	}{
+		{name: "no flags", args: []string{"90m", "h"}, positional: []string{"90m", "h"}},
+		{name: "brief before", args: []string{"-b", "90m", "h"}, positional: []string{"90m", "h"}, brief: true},
+		{name: "brief after", args: []string{"90m", "h", "-b"}, positional: []string{"90m", "h"}, brief: true},
+		{name: "brief long", args: []string{"--brief", "90m", "h"}, positional: []string{"90m", "h"}, brief: true},
+		{name: "nonewline", args: []string{"-n", "90m", "h"}, positional: []string{"90m", "h"}, noNewline: true},
+		{name: "nonewline long", args: []string{"--nonewline", "90m", "h"}, positional: []string{"90m", "h"}, noNewline: true},
+		{name: "combined shorthand", args: []string{"-bn", "90m", "h"}, positional: []string{"90m", "h"}, brief: true, noNewline: true},
+		{name: "separate shorthands", args: []string{"-n", "-b", "90m", "h"}, positional: []string{"90m", "h"}, brief: true, noNewline: true},
+		{name: "help short", args: []string{"-h"}, help: true},
+		{name: "help long", args: []string{"--help"}, help: true},
+		{name: "negative brief duration", args: []string{"-90m", "h"}, positional: []string{"-90m", "h"}},
+		{name: "negative verbose duration", args: []string{"-1 hour 30 minutes", "m"}, positional: []string{"-1 hour 30 minutes", "m"}},
+		{name: "negative duration with flag", args: []string{"-b", "-90m", "h"}, positional: []string{"-90m", "h"}, brief: true},
+		{name: "double dash terminator", args: []string{"-b", "--", "-90m", "h"}, positional: []string{"-90m", "h"}, brief: true},
+		{name: "unknown shorthand", args: []string{"-x", "90m", "h"}, wantErr: true},
+		{name: "unknown shorthand in cluster", args: []string{"-bx", "90m", "h"}, wantErr: true},
+		{name: "unknown long flag", args: []string{"--bogus", "90m", "h"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			positional, brief, noNewline, help, err := parseConvArgs(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Equal(positional, tt.positional) {
+				t.Errorf("positional: [computed: %v] != [correct: %v]", positional, tt.positional)
+			}
+			if brief != tt.brief {
+				t.Errorf("brief: [computed: %v] != [correct: %v]", brief, tt.brief)
+			}
+			if noNewline != tt.noNewline {
+				t.Errorf("noNewline: [computed: %v] != [correct: %v]", noNewline, tt.noNewline)
+			}
+			if help != tt.help {
+				t.Errorf("help: [computed: %v] != [correct: %v]", help, tt.help)
+			}
+		})
+	}
+}

--- a/dur.go
+++ b/dur.go
@@ -3,8 +3,8 @@ package DateTimeMate
 import (
 	"fmt"
 	"github.com/golang-module/carbon/v2"
-	"github.com/lestrrat-go/strftime"
 	"github.com/jftuga/parsetime"
+	"github.com/lestrrat-go/strftime"
 	"os"
 	"regexp"
 	"strconv"


### PR DESCRIPTION
## Issue

The `-b` (brief) and `-n` (nonewline, global) options were not implemented for `dtmate conv`:

```
$ dtmate conv -b 90m h
Error: accepts 2 arg(s), received 3
```

`convCmd` sets `DisableFlagParsing: true` so that negative durations (e.g. `dtmate conv -90m h`) are not rejected as unknown flags. As a side effect, cobra never parsed any flags for `conv`: `-b` was declared and shown in the help text but dead code, `-n` was ignored, and even `conv -h` failed with an argument-count error. The README documents `dtmate conv 42W4D6h43m21s seconds -b`, which did not work.

Fixes #23

## Changes

* **`cmd/dtmate/cmd/conv.go`:** Keep `DisableFlagParsing: true` (still required for negative durations) and extract flags manually in a new `parseConvArgs` helper before validating the two positional arguments. An argument starting with `-` followed by a digit is treated as a negative duration; anything else starting with `-` is a flag. Supports `-b`/`--brief`, `-n`/`--nonewline`, `-h`/`--help`, combined shorthands such as `-bn`, and `--` as a flag terminator, matching pflag behavior on the other sub-commands. The command now uses `RunE`, so unknown flags and wrong argument counts produce a proper cobra error plus usage, and `conv -h` shows help.
* **`cmd/dtmate/cmd/conv_test.go`:** New table-driven test covering `parseConvArgs`: flag positions, long forms, combined shorthands, negative durations (brief and verbose), the `--` terminator, help, and unknown-flag errors.
* **`dur.go`:** gofmt import ordering fix (pre-existing, unrelated to the feature).
* **Version:** Bumped `ModVersion` to 1.5.0.

## Testing

* `go build ./...`, `go vet ./...`, `gofmt -l .`, and all tests pass (17 new test cases).
* Verified end-to-end against the built binary:
  * `dtmate conv -b "42 weeks 4 days 6 hours 43 minutes 21 seconds" seconds` → `25771401s`
  * `dtmate conv 42W4D6h43m21s seconds -b` → `25771401s` (README example now works)
  * `dtmate conv -n 90m h` and `dtmate -n conv 90m h` → `1 hour` with no trailing newline
  * `dtmate conv -bn 4321s hms` → `1h12m1s` with no trailing newline
  * `dtmate conv -90m h` and `dtmate conv -- -90m h` → `-1 hour` (negative durations still work)
  * `dtmate conv -h` → shows help (previously errored)
  * `dtmate conv -x 90m h` → `unknown shorthand flag: 'x' in -x` plus usage
  * `dtmate conv 90m` → `accepts 2 arg(s), received 1`
