### PR TITLE
Add `-d`/`--decimals` flag for decimal output on the smallest unit

### DIFF
--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -21,7 +21,7 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.5.0"
+	ModVersion string = "1.6.0"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ Conversions:
 Months are not a unit since their lengths vary between 28 and 31 days
 Separate sub-second brief units with a dot
 example: dtmate conv 4321s123456789ns hms.msusns
+Use -d to show the smallest unit with decimal places, rounded
+example: dtmate diff 2023-10-17 2026-07-04 -c Y -d 2  =>  2.71 years
 ```
 
 </details>
@@ -233,6 +235,11 @@ $ dtmate diff 2024-06-07T08:00:00Z 2024-06-07T08:05:05-05:00
 # same input, also convert duration to minutes and seconds
 $ dtmate diff 2024-06-07T08:00:00Z 2024-06-07T08:05:05-05:00 -c ms
 305 minutes 5 seconds
+
+# convert to a single unit, showing 2 decimal places
+# without -d, this would truncate to just: 2 years
+$ dtmate diff 2023-10-17 2026-07-04 -c Y -d 2
+2.71 years
 
 # differentiate sub-second durations with a dot
 # note the "ms" on both sides of the dot: minutes & seconds vs milliseconds
@@ -324,6 +331,10 @@ $ dtmate conv 25771401s WDhms
 # another conversion, in the opposite direction, brief output
 $ dtmate conv 42W4D6h43m21s seconds -b
 25771401s
+
+# show the smallest unit with decimal places, rounded
+$ dtmate conv "1 hour 30 minutes" hours -d 1
+1.5 hours
 
 ########################### "dtmate fmt" examples ###########################
 

--- a/cmd/dtmate/cmd/conv.go
+++ b/cmd/dtmate/cmd/conv.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jftuga/DateTimeMate"
@@ -11,6 +12,7 @@ import (
 )
 
 var optConvBrief bool
+var optConvDecimals int
 
 var convCmd = &cobra.Command{
 	Use:                "conv [source duration] [target duration]",
@@ -18,7 +20,7 @@ var convCmd = &cobra.Command{
 	Args:               cobra.ArbitraryArgs,
 	DisableFlagParsing: true, // this allows for negative durations; flags are parsed manually in RunE
 	RunE: func(cmd *cobra.Command, args []string) error {
-		positional, brief, noNewline, help, err := parseConvArgs(args)
+		positional, brief, noNewline, help, decimals, err := parseConvArgs(args)
 		if err != nil {
 			return err
 		}
@@ -29,10 +31,11 @@ var convCmd = &cobra.Command{
 			return fmt.Errorf("accepts 2 arg(s), received %d", len(positional))
 		}
 		optConvBrief = brief
+		optConvDecimals = decimals
 		if noNewline {
 			optRootNoNewline = true
 		}
-		outputConvDuration(positional[0], positional[1], optConvBrief)
+		outputConvDuration(positional[0], positional[1], optConvBrief, optConvDecimals)
 		return nil
 	},
 }
@@ -40,47 +43,79 @@ var convCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(convCmd)
 	convCmd.Flags().BoolVarP(&optConvBrief, "brief", "b", false, "output in brief format, such as: 1Y2M3D4h5m6s7ms8us9ns")
+	convCmd.Flags().IntVarP(&optConvDecimals, "decimals", "d", 0, "show the smallest unit with this many decimal places, rounded")
 }
 
 // parseConvArgs manually separates flags from positional args because convCmd
 // disables cobra flag parsing to support negative durations; an arg starting
 // with "-" followed by a digit is a negative duration, not a flag
-func parseConvArgs(args []string) (positional []string, brief, noNewline, help bool, err error) {
-	for i, arg := range args {
+func parseConvArgs(args []string) (positional []string, brief, noNewline, help bool, decimals int, err error) {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
 		switch {
 		case arg == "--":
 			positional = append(positional, args[i+1:]...)
-			return positional, brief, noNewline, help, nil
+			return positional, brief, noNewline, help, decimals, nil
 		case arg == "--brief":
 			brief = true
 		case arg == "--nonewline":
 			noNewline = true
 		case arg == "--help":
 			help = true
+		case arg == "--decimals":
+			if i+1 >= len(args) {
+				return nil, false, false, false, 0, fmt.Errorf("flag needs an argument: --decimals")
+			}
+			i++
+			decimals, err = strconv.Atoi(args[i])
+			if err != nil {
+				return nil, false, false, false, 0, fmt.Errorf("invalid argument %q for --decimals", args[i])
+			}
+		case strings.HasPrefix(arg, "--decimals="):
+			value := strings.TrimPrefix(arg, "--decimals=")
+			decimals, err = strconv.Atoi(value)
+			if err != nil {
+				return nil, false, false, false, 0, fmt.Errorf("invalid argument %q for --decimals", value)
+			}
 		case strings.HasPrefix(arg, "--"):
-			return nil, false, false, false, fmt.Errorf("unknown flag: %s", arg)
+			return nil, false, false, false, 0, fmt.Errorf("unknown flag: %s", arg)
 		case len(arg) > 1 && arg[0] == '-' && (arg[1] < '0' || arg[1] > '9'):
-			for _, shorthand := range arg[1:] {
-				switch shorthand {
+			for j := 1; j < len(arg); j++ {
+				switch arg[j] {
 				case 'b':
 					brief = true
 				case 'n':
 					noNewline = true
 				case 'h':
 					help = true
+				case 'd':
+					// 'd' takes a value: the rest of this arg (-d2) or the next arg (-d 2)
+					value := arg[j+1:]
+					if value == "" {
+						if i+1 >= len(args) {
+							return nil, false, false, false, 0, fmt.Errorf("flag needs an argument: 'd' in %s", arg)
+						}
+						i++
+						value = args[i]
+					}
+					decimals, err = strconv.Atoi(value)
+					if err != nil {
+						return nil, false, false, false, 0, fmt.Errorf("invalid argument %q for -d", value)
+					}
+					j = len(arg)
 				default:
-					return nil, false, false, false, fmt.Errorf("unknown shorthand flag: %q in %s", shorthand, arg)
+					return nil, false, false, false, 0, fmt.Errorf("unknown shorthand flag: %q in %s", arg[j], arg)
 				}
 			}
 		default:
 			positional = append(positional, arg)
 		}
 	}
-	return positional, brief, noNewline, help, nil
+	return positional, brief, noNewline, help, decimals, nil
 }
 
-func outputConvDuration(source, target string, brief bool) {
-	conv := DateTimeMate.NewConv(DateTimeMate.ConvWithSource(source), DateTimeMate.ConvWithTarget(target), DateTimeMate.ConvWithBrief(brief))
+func outputConvDuration(source, target string, brief bool, decimals int) {
+	conv := DateTimeMate.NewConv(DateTimeMate.ConvWithSource(source), DateTimeMate.ConvWithTarget(target), DateTimeMate.ConvWithBrief(brief), DateTimeMate.ConvWithDecimals(decimals))
 	result, err := conv.ConvertDuration()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/dtmate/cmd/conv_test.go
+++ b/cmd/dtmate/cmd/conv_test.go
@@ -13,6 +13,7 @@ func TestParseConvArgs(t *testing.T) {
 		brief      bool
 		noNewline  bool
 		help       bool
+		decimals   int
 		wantErr    bool
 	}{
 		{name: "no flags", args: []string{"90m", "h"}, positional: []string{"90m", "h"}},
@@ -29,6 +30,18 @@ func TestParseConvArgs(t *testing.T) {
 		{name: "negative verbose duration", args: []string{"-1 hour 30 minutes", "m"}, positional: []string{"-1 hour 30 minutes", "m"}},
 		{name: "negative duration with flag", args: []string{"-b", "-90m", "h"}, positional: []string{"-90m", "h"}, brief: true},
 		{name: "double dash terminator", args: []string{"-b", "--", "-90m", "h"}, positional: []string{"-90m", "h"}, brief: true},
+		{name: "decimals separate", args: []string{"-d", "2", "90m", "h"}, positional: []string{"90m", "h"}, decimals: 2},
+		{name: "decimals attached", args: []string{"-d2", "90m", "h"}, positional: []string{"90m", "h"}, decimals: 2},
+		{name: "decimals in cluster", args: []string{"-bd2", "90m", "h"}, positional: []string{"90m", "h"}, brief: true, decimals: 2},
+		{name: "decimals in cluster separate value", args: []string{"-bd", "3", "90m", "h"}, positional: []string{"90m", "h"}, brief: true, decimals: 3},
+		{name: "decimals long", args: []string{"--decimals", "2", "90m", "h"}, positional: []string{"90m", "h"}, decimals: 2},
+		{name: "decimals long equals", args: []string{"--decimals=4", "90m", "h"}, positional: []string{"90m", "h"}, decimals: 4},
+		{name: "decimals after positionals", args: []string{"90m", "h", "-d", "2"}, positional: []string{"90m", "h"}, decimals: 2},
+		{name: "decimals with negative duration", args: []string{"-d", "2", "-90m", "h"}, positional: []string{"-90m", "h"}, decimals: 2},
+		{name: "decimals missing value", args: []string{"90m", "h", "-d"}, wantErr: true},
+		{name: "decimals missing value long", args: []string{"90m", "h", "--decimals"}, wantErr: true},
+		{name: "decimals bad value", args: []string{"-d", "x", "90m", "h"}, wantErr: true},
+		{name: "decimals bad value long equals", args: []string{"--decimals=x", "90m", "h"}, wantErr: true},
 		{name: "unknown shorthand", args: []string{"-x", "90m", "h"}, wantErr: true},
 		{name: "unknown shorthand in cluster", args: []string{"-bx", "90m", "h"}, wantErr: true},
 		{name: "unknown long flag", args: []string{"--bogus", "90m", "h"}, wantErr: true},
@@ -36,7 +49,7 @@ func TestParseConvArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			positional, brief, noNewline, help, err := parseConvArgs(tt.args)
+			positional, brief, noNewline, help, decimals, err := parseConvArgs(tt.args)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected an error, got nil")
@@ -57,6 +70,9 @@ func TestParseConvArgs(t *testing.T) {
 			}
 			if help != tt.help {
 				t.Errorf("help: [computed: %v] != [correct: %v]", help, tt.help)
+			}
+			if decimals != tt.decimals {
+				t.Errorf("decimals: [computed: %v] != [correct: %v]", decimals, tt.decimals)
 			}
 		})
 	}

--- a/cmd/dtmate/cmd/diff.go
+++ b/cmd/dtmate/cmd/diff.go
@@ -41,12 +41,14 @@ var diffCmd = &cobra.Command{
 var optDiffBrief bool
 var optDiffReadFromStdin bool
 var optDiffConv string
+var optDiffDecimals int
 
 func init() {
 	rootCmd.AddCommand(diffCmd)
 	diffCmd.Flags().BoolVarP(&optDiffBrief, "brief", "b", false, "output in brief format, such as: 1Y2M3D4h5m6s7ms8us9ns")
 	diffCmd.Flags().BoolVarP(&optDiffReadFromStdin, "stdin", "i", false, "read from STDIN instead of using -s/-e")
 	diffCmd.Flags().StringVarP(&optDiffConv, "conv", "c", "", "convert resulting duration to another group of units")
+	diffCmd.Flags().IntVarP(&optDiffDecimals, "decimals", "d", 0, "with -c: show the smallest unit with this many decimal places, rounded")
 }
 
 // either read one line containing a comma, then split start and end on this
@@ -69,8 +71,8 @@ func getInput() (string, string) {
 }
 
 // convert duration from one group of units to another
-func convDuration(source, target string, brief bool) string {
-	conv := DateTimeMate.NewConv(DateTimeMate.ConvWithSource(source), DateTimeMate.ConvWithTarget(target), DateTimeMate.ConvWithBrief(brief))
+func convDuration(source, target string, brief bool, decimals int) string {
+	conv := DateTimeMate.NewConv(DateTimeMate.ConvWithSource(source), DateTimeMate.ConvWithTarget(target), DateTimeMate.ConvWithBrief(brief), DateTimeMate.ConvWithDecimals(decimals))
 	result, err := conv.ConvertDuration()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -81,6 +83,10 @@ func convDuration(source, target string, brief bool) string {
 
 // outputDiff compute the duration between two dates, times, and/or date/times
 func outputDiff(start, end string, brief bool) {
+	if optDiffDecimals != 0 && optDiffConv == "" {
+		fmt.Fprintln(os.Stderr, "-d/--decimals requires -c/--conv")
+		os.Exit(1)
+	}
 	diff := DateTimeMate.NewDiff(DateTimeMate.DiffWithStart(start), DateTimeMate.DiffWithEnd(end), DateTimeMate.DiffWithBrief(brief))
 	result, _, err := diff.CalculateDiff()
 	if err != nil {
@@ -88,7 +94,7 @@ func outputDiff(start, end string, brief bool) {
 		os.Exit(1)
 	}
 	if optDiffConv != "" {
-		result = convDuration(result, optDiffConv, optDiffBrief)
+		result = convDuration(result, optDiffConv, optDiffBrief, optDiffDecimals)
 	}
 	if optRootNoNewline {
 		fmt.Print(result)

--- a/cmd/dtmate/cmd/root.go
+++ b/cmd/dtmate/cmd/root.go
@@ -40,6 +40,8 @@ Conversions:
 Months are not a unit since their lengths vary between 28 and 31 days
 Separate sub-second brief units with a dot
 example: dtmate conv 4321s123456789ns hms.msusns
+Use -d to show the smallest unit with decimal places, rounded
+example: dtmate diff 2023-10-17 2026-07-04 -c Y -d 2  =>  2.71 years
 `
 
 // rootCmd represents the base command when called without any subcommands

--- a/conv.go
+++ b/conv.go
@@ -42,9 +42,10 @@ var unitBriefMap = map[string]string{
 }
 
 type Conv struct {
-	Source string
-	Target string
-	Brief  bool
+	Source   string
+	Target   string
+	Brief    bool
+	Decimals int
 }
 
 type OptionsConv func(*Conv)
@@ -75,8 +76,16 @@ func ConvWithBrief(brief bool) OptionsConv {
 	}
 }
 
+// ConvWithDecimals sets the number of decimal places used when formatting
+// the last (smallest) target unit; 0 keeps the default integer truncation
+func ConvWithDecimals(decimals int) OptionsConv {
+	return func(conv *Conv) {
+		conv.Decimals = decimals
+	}
+}
+
 func (conv *Conv) String() string {
-	return fmt.Sprintf("Source:%v Target:%v Brief:%v", conv.Source, conv.Target, conv.Brief)
+	return fmt.Sprintf("Source:%v Target:%v Brief:%v Decimals:%v", conv.Source, conv.Target, conv.Brief, conv.Decimals)
 }
 
 // parseSource parses the Source field of the Conv struct
@@ -121,21 +130,36 @@ func (conv *Conv) parseSource() (float64, error) {
 // each unit as appropriate. It builds a string representation, including only non-zero
 // values. The function handles singular and plural forms of the units.
 //
+// When Conv.Decimals is greater than zero, the last (smallest) unit is formatted with
+// that many decimal places, rounded, and is always included even when less than one.
+//
 // Returns:
 //   - string: A formatted string representing the duration using the specified units.
 //     For example: "2 hours 30 minutes 45 seconds"
 func (conv *Conv) formatTarget(seconds float64, units []string) string {
 	result := ""
-	for _, unit := range units {
+	for i, unit := range units {
 		unitInSeconds := unitMap[strings.TrimSuffix(unit, "s")]
 		value := seconds / unitInSeconds
-		intValue := int(value)
+		unit = removeTrailingS(unit)
 
+		if conv.Decimals > 0 && i == len(units)-1 {
+			if value < 0 { // guard against float underflow producing "-0.00"
+				value = 0
+			}
+			formatted := strconv.FormatFloat(value, 'f', conv.Decimals, 64)
+			if rounded, _ := strconv.ParseFloat(formatted, 64); rounded != 1 {
+				unit += "s"
+			}
+			result += fmt.Sprintf("%s %s ", formatted, unit)
+			continue
+		}
+
+		intValue := int(value)
 		if intValue <= 0 {
 			continue
 		}
 
-		unit = removeTrailingS(unit)
 		if intValue > 1 {
 			unit += "s"
 		}
@@ -217,6 +241,9 @@ func expandBriefTargetDuration(period string) ([]string, error) {
 //   - error: An error if any step of the conversion process fails.
 func (conv *Conv) ConvertDuration() (string, error) {
 	var err error
+	if conv.Decimals < 0 || conv.Decimals > 9 {
+		return "", fmt.Errorf("decimals must be between 0 and 9: %d", conv.Decimals)
+	}
 	isNegativeDuration := false
 	if s, found := strings.CutPrefix(conv.Source, "-"); found {
 		conv.Source = s

--- a/conv_test.go
+++ b/conv_test.go
@@ -18,6 +18,82 @@ func testConv(t *testing.T, source, target string, brief bool, correct string) {
 	}
 }
 
+func testConvDecimals(t *testing.T, source, target string, brief bool, decimals int, correct string) {
+	t.Helper()
+	conv := NewConv(
+		ConvWithSource(source),
+		ConvWithTarget(target),
+		ConvWithBrief(brief),
+		ConvWithDecimals(decimals))
+
+	result, err := conv.ConvertDuration()
+	if err != nil {
+		t.Error(err)
+	}
+	if result != correct {
+		t.Errorf("\n[computed: %v] !=\n[correct : %v]", result, correct)
+	}
+}
+
+func TestConvDecimals(t *testing.T) {
+	t.Parallel()
+	// the example from issue #31
+	source := "2 years 37 weeks 2 days"
+	target := "years"
+	correct := "2.71 years"
+	testConvDecimals(t, source, target, false, 2, correct)
+
+	correct = "2.71Y"
+	testConvDecimals(t, source, target, true, 2, correct)
+
+	source = "-2 years 37 weeks 2 days"
+	correct = "-2.71 years"
+	testConvDecimals(t, source, target, false, 2, correct)
+
+	// decimals only apply to the last (smallest) unit
+	source = "2 years 37 weeks 2 days"
+	target = "years weeks"
+	correct = "2 years 37.29 weeks"
+	testConvDecimals(t, source, target, false, 2, correct)
+
+	source = "1 hour 30 minutes"
+	target = "hours"
+	correct = "1.5 hours"
+	testConvDecimals(t, source, target, false, 1, correct)
+
+	// a value rounding to exactly one is singular
+	source = "365 days 6 hours"
+	target = "years"
+	correct = "1.00 year"
+	testConvDecimals(t, source, target, false, 2, correct)
+
+	// the last unit is included even when less than one
+	source = "3 days"
+	target = "years"
+	correct = "0.01 years"
+	testConvDecimals(t, source, target, false, 2, correct)
+
+	// zero decimals preserves the default truncation behavior
+	source = "2 years 37 weeks 2 days"
+	target = "years"
+	correct = "2 years"
+	testConvDecimals(t, source, target, false, 0, correct)
+}
+
+func TestConvDecimalsOutOfRange(t *testing.T) {
+	t.Parallel()
+	for _, decimals := range []int{-1, 10} {
+		conv := NewConv(
+			ConvWithSource("90 minutes"),
+			ConvWithTarget("hours"),
+			ConvWithDecimals(decimals))
+		_, err := conv.ConvertDuration()
+		if err == nil {
+			t.Errorf("expected an error for decimals=%d, got nil", decimals)
+		}
+	}
+}
+
 func TestConvHoursMinutesSeconds(t *testing.T) {
 	t.Parallel()
 	source := "386 hours 24 minutes 36 seconds"


### PR DESCRIPTION
## Issue

Converting a duration to a single coarse unit silently truncates the remainder:

```
$ dtmate diff 2023-10-17 2026-07-04 -c Y
2 years
```

That drops ~37 weeks with no indication. Issue #31 requested an optional decimal output, e.g. `2.71 years`.

Fixes #31

## Changes

* **New opt-in flag `-d, --decimals N`** on `dtmate diff` and `dtmate conv` (0 = off/default, max 9). Decimals apply only to the last (smallest) requested unit and are rounded:

```
$ dtmate diff 2023-10-17 2026-07-04 -c Y -d 2
2.71 years
$ dtmate conv "2 years 37 weeks 2 days" YW -d 2
2 years 37.29 weeks
```

With `-d`, the last unit is shown even when less than one (`0.01 years` instead of empty output), a value rounding to exactly 1 is singular (`1.00 year`), and brief mode works (`2.71Y`). The conversion uses the existing 1 year = 365.25 days convention. Default output is unchanged.

* **`conv.go`:** `Conv` gains a `Decimals` field and `ConvWithDecimals` option. `ConvertDuration` validates the 0–9 range; `formatTarget` formats the last unit with `strconv.FormatFloat` when decimals are enabled.
* **`cmd/dtmate/cmd/diff.go`:** New `-d` flag; using it without `-c` is an error since decimals only apply to converted output.
* **`cmd/dtmate/cmd/conv.go`:** The manual flag parser (required because `DisableFlagParsing` supports negative durations) now handles the value-taking flag in all pflag forms: `-d 2`, `-d2`, `-bd2`, `-bd 2`,
`--decimals 2`, `--decimals=2`, plus missing/invalid value errors.
* **`README.md` / `cmd/dtmate/cmd/root.go`:** New examples and a note in the extended help "Conversions" section.
* **Version:** Bumped `ModVersion` to 1.6.0.

## Testing

* `go build ./...`, `go vet ./...`, `gofmt -l .`, and all tests pass (`TestConvDecimals`, `TestConvDecimalsOutOfRange`, and 12 new `parseConvArgs` cases).
* Verified end-to-end against the built binary:
* `dtmate diff 2023-10-17 2026-07-04 -c Y -d 2` → `2.71 years`
* `dtmate diff 2023-10-17 2026-07-04 -c Y` → `2 years` (default unchanged)
* `dtmate diff 2023-10-17 2026-07-04 -c YW -d 2` → `2 years 37.29 weeks`
* `dtmate conv "1 hour 30 minutes" hours -d 1` → `1.5 hours`
* `dtmate conv "2 years 37 weeks 2 days" Y -d2 -b` → `2.71Y`
* `dtmate conv -d 2 -90m h` → `-1.50 hours` (negative durations still work)
* `dtmate conv 365D6h Y -d 2` → `1.00 year` (singular)
* `dtmate conv 3D Y -d 2` → `0.01 years` (sub-one values no longer empty)
* `dtmate diff 12:00 13:00 -d 2` → `-d/--decimals requires -c/--conv`
* `dtmate conv 90m h -d 10` → `decimals must be between 0 and 9: 10`
* `dtmate conv 90m h -d x` → `invalid argument "x" for -d` plus usage
