### PR TITLE
Tighten help output and add --help-all flag

### DIFF
--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -21,7 +21,7 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.6.0"
+	ModVersion string = "1.7.0"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 

--- a/cmd/dtmate/cmd/conv.go
+++ b/cmd/dtmate/cmd/conv.go
@@ -15,8 +15,10 @@ var optConvBrief bool
 var optConvDecimals int
 
 var convCmd = &cobra.Command{
-	Use:                "conv [source duration] [target duration]",
-	Short:              "Convert a duration from group of units to another",
+	Use:   "conv [source duration] [target duration]",
+	Short: "Convert a duration from group of units to another",
+	Example: `  dtmate conv 90m hm
+  dtmate conv 4321s123456789ns hms.msusns`,
 	Args:               cobra.ArbitraryArgs,
 	DisableFlagParsing: true, // this allows for negative durations; flags are parsed manually in RunE
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -42,7 +44,7 @@ var convCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(convCmd)
-	convCmd.Flags().BoolVarP(&optConvBrief, "brief", "b", false, "output in brief format, such as: 1Y2M3D4h5m6s7ms8us9ns")
+	convCmd.Flags().BoolVarP(&optConvBrief, "brief", "b", false, "output in brief format, such as: 1Y3W4D5h6m7s")
 	convCmd.Flags().IntVarP(&optConvDecimals, "decimals", "d", 0, "show the smallest unit with this many decimal places, rounded")
 }
 

--- a/cmd/dtmate/cmd/diff.go
+++ b/cmd/dtmate/cmd/diff.go
@@ -15,6 +15,8 @@ import (
 var diffCmd = &cobra.Command{
 	Use:   "diff [start] [end]",
 	Short: "Output the difference between two date/times",
+	Example: `  dtmate diff 12:00:00 15:30:45
+  dtmate diff 2024-06-07T08:00:00Z 2024-06-08T09:02:03Z --conv s -b`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if optDiffReadFromStdin {
 			if len(args) == 0 {
@@ -45,7 +47,7 @@ var optDiffDecimals int
 
 func init() {
 	rootCmd.AddCommand(diffCmd)
-	diffCmd.Flags().BoolVarP(&optDiffBrief, "brief", "b", false, "output in brief format, such as: 1Y2M3D4h5m6s7ms8us9ns")
+	diffCmd.Flags().BoolVarP(&optDiffBrief, "brief", "b", false, "output in brief format, such as: 1Y3W4D5h6m7s")
 	diffCmd.Flags().BoolVarP(&optDiffReadFromStdin, "stdin", "i", false, "read from STDIN instead of using -s/-e")
 	diffCmd.Flags().StringVarP(&optDiffConv, "conv", "c", "", "convert resulting duration to another group of units")
 	diffCmd.Flags().IntVarP(&optDiffDecimals, "decimals", "d", 0, "with -c: show the smallest unit with this many decimal places, rounded")

--- a/cmd/dtmate/cmd/dur.go
+++ b/cmd/dtmate/cmd/dur.go
@@ -13,7 +13,9 @@ import (
 var durCmd = &cobra.Command{
 	Use:   "dur [from] [duration]",
 	Short: "Output a date/time when given a starting date/time and duration",
-	Args:  cobra.MatchAll(cobra.ExactArgs(2)),
+	Example: `  dtmate dur now 1D2h -a
+  dtmate dur today 7h10m -a -u tomorrow`,
+	Args: cobra.MatchAll(cobra.ExactArgs(2)),
 	Run: func(cmd *cobra.Command, args []string) {
 		outputDur(args[0], args[1], optDurUntil, optDurFormat, optDurRepeat)
 	},
@@ -30,8 +32,8 @@ var (
 
 func init() {
 	rootCmd.AddCommand(durCmd)
-	durCmd.Flags().BoolVarP(&optDurAdd, "add", "a", false, "add: a duration to use with -f, such as '1D2h3s' or '1 day 2 hours 3 seconds'")
-	durCmd.Flags().BoolVarP(&optDurSub, "sub", "s", false, "subtract: a duration to use with -f, such as '4 weeks 3 days 2 hours'")
+	durCmd.Flags().BoolVarP(&optDurAdd, "add", "a", false, "add the duration to the starting date/time")
+	durCmd.Flags().BoolVarP(&optDurSub, "sub", "s", false, "subtract the duration from the starting date/time")
 	durCmd.Flags().StringVarP(&optDurUntil, "until", "u", "", "repeat duration until this date/time is exceeded")
 	durCmd.Flags().StringVarP(&optDurFormat, "format", "f", "", "output results with strftime formatting")
 	durCmd.Flags().IntVarP(&optDurRepeat, "repeat", "r", 0, "repeat the -a or -s duration this number of times (mutually exclusive with -u)")

--- a/cmd/dtmate/cmd/fmt.go
+++ b/cmd/dtmate/cmd/fmt.go
@@ -11,7 +11,9 @@ import (
 
 var fmtCmd = &cobra.Command{
 	Use:   "fmt [date/time] [format specifiers]",
-	Short: "reformat a date/time",
+	Short: "Reformat a date/time",
+	Example: `  dtmate fmt "2024-06-07 08:01:02" "%v %r"
+  dtmate fmt now %s`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if optFmtList {
 			return nil

--- a/cmd/dtmate/cmd/root.go
+++ b/cmd/dtmate/cmd/root.go
@@ -9,54 +9,49 @@ import (
 )
 
 const extendedHelp string = `
----
+DURATION UNITS
+  years  weeks  days  hours  minutes  seconds  milliseconds  microseconds  nanoseconds
+  example: '1 year 3 days 4 hours 1 minute 6 seconds'
 
-Durations:
-years weeks days
-hours minutes seconds milliseconds microseconds nanoseconds
-example: '1 year 3 days 4 hours 1 minute 6 seconds'
+BRIEF UNITS  (date units uppercase, time units lowercase)
+  Y  W  D          years, weeks, days
+  h  m  s          hours, minutes, seconds
+  ms us ns         milliseconds, microseconds, nanoseconds
+  examples: 1Y3W4D5h6m7s8ms9us1ns  or  '1Y 3W 4D 5h 6m 7s'
 
----
+RELATIVE DATE SHORTCUTS
+  now, today       the current time
+  yesterday        exactly 24 hours before now
+  tomorrow         exactly 24 hours after now
+  example: dtmate dur today 7h10m -a -u tomorrow
 
-Brief Durations:
-(dates are always uppercase, times are always lowercase)
-Y    W    D
-h    m    s    ms    us    ns
-examples: 1Y3W4D5h6m7s8ms9us1ns, '1Y 3W 4D 5h 6m 7s 8ms 9us 1ns'
-
----
-
-Relative Date Shortcuts:
-now
-today (returns same value as now)
-yesterday (exactly 24 hours behind of the current time)
-tomorrow (exactly 24 hours ahead the current time)
-example: dtmate dur today 7h10m -a -u tomorrow
-
----
-
-Conversions:
-1 year is equal to 365.25 days
-Months are not a unit since their lengths vary between 28 and 31 days
-Separate sub-second brief units with a dot
-example: dtmate conv 4321s123456789ns hms.msusns
-Use -d to show the smallest unit with decimal places, rounded
-example: dtmate diff 2023-10-17 2026-07-04 -c Y -d 2  =>  2.71 years
+CONVERSION NOTES
+  1 year equals 365.25 days
+  months are not a unit; their lengths vary between 28 and 31 days
+  separate sub-second brief target units with a dot:
+    dtmate conv 4321s123456789ns hms.msusns
+  use -d to round the smallest unit to N decimal places:
+    dtmate diff 2023-10-17 2026-07-04 -c Y -d 2  =>  2.71 years
 `
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:     "dtmate",
-	Short:   "dtmate: output the difference between date, time or duration",
+	Short:   "Compute date/time differences, durations, conversions, and reformatting",
 	Version: DateTimeMate.ModVersion,
 	Run: func(cmd *cobra.Command, args []string) {
 		if optRootShowExamples {
 			ShowExamples()
 			os.Exit(0)
 		}
+		if optRootHelpAll {
+			cmd.Help() //nolint:errcheck
+			fmt.Print(extendedHelp)
+			os.Exit(0)
+		}
 
 		// if no arguments are provided and no flags are set, show help
-		if len(args) == 0 && !cmd.Flags().Changed("examples") {
+		if len(args) == 0 && !cmd.Flags().Changed("examples") && !cmd.Flags().Changed("help-all") {
 			cmd.Help() //nolint:errcheck
 		}
 	},
@@ -64,6 +59,7 @@ var rootCmd = &cobra.Command{
 
 var optRootNoNewline bool
 var optRootShowExamples bool
+var optRootHelpAll bool
 var readmeExamplesRegex = regexp.MustCompile(`(?ms)## Command Line Examples.*?shell\n(.*?)` + "```")
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -78,11 +74,12 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&optRootNoNewline, "nonewline", "n", false, "do not output a newline character")
 	rootCmd.Flags().BoolVarP(&optRootShowExamples, "examples", "e", false, "show command-line examples")
+	rootCmd.Flags().BoolVar(&optRootHelpAll, "help-all", false, "show help plus duration syntax, brief units, and conversion notes")
 
 	versionTemplate := fmt.Sprintf("dtmate version %s\n%s\n", DateTimeMate.ModVersion, DateTimeMate.ModUrl)
 	rootCmd.SetVersionTemplate(versionTemplate)
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
-	rootCmd.SetUsageTemplate(rootCmd.UsageTemplate() + extendedHelp)
+	rootCmd.SetUsageTemplate(rootCmd.UsageTemplate() + "\nUse \"dtmate --help-all\" for duration syntax, brief units, and conversion notes.\n")
 }
 
 func extractReadmeExamples(markdown string) string {


### PR DESCRIPTION

## Summary

Every help screen (root plus all four verbs) previously ended with the same ~45-line reference block covering duration units, brief units, relative date shortcuts, and conversion notes. The cause was a single line in `root.go` that appended the block to the cobra usage template, which subcommands inherit. This PR makes that reference opt-in and tightens each verb's help screen.

## Changes

- **New `--help-all` flag** on the root command. It prints the standard help followed by the full reference, now reshaped into four aligned sections: DURATION UNITS, BRIEF UNITS, RELATIVE DATE SHORTCUTS, and CONVERSION NOTES. The flag is root-only by design; `conv` disables cobra flag parsing and is intentionally left untouched.
- **One-line pointer on every help screen.** The inherited usage template now appends only: `Use "dtmate --help-all" for duration syntax, brief units, and conversion notes.`
- **Examples sections** added to `conv`, `diff`, `dur`, and `fmt`, using commands verified against the built binary.
- **Flag text fixes:**
- `-b/--brief` on `conv` and `diff` showed `1Y2M3D4h5m6s7ms8us9ns`, but `M` (months) has not been a unit since #26. Now `1Y3W4D5h6m7s`.
- `dur -a/--add` and `-s/--sub` claimed the duration is "used with -f", but `-f` is the strftime format flag; the duration is a positional argument. Reworded.
- **Description polish:** the root `Short` no longer implies the tool only computes differences; `fmt`'s `Short` is capitalized to match the other verbs.
- **Version bump** to 1.7.0.

## Verification

- `dtmate` and `dtmate <verb> --help` show only usage, examples, flags, and the one-line pointer; `dtmate --help-all` shows help plus the full reference.
- All nine example commands from the new help text run successfully.
- `-e/--examples` and `-h/--help` behavior unchanged.
- `go test ./...` passes (62 tests, 4 packages).
