### PR TITLE
Fix 14 bugs across conv, dur, diff, and fmt; bump version to 1.8.0

### DIFF
--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -21,7 +21,7 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.7.0"
+	ModVersion string = "1.8.0"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 
@@ -83,10 +83,37 @@ func removeTrailingS(s string) string {
 	return strings.TrimSuffix(s, "s")
 }
 
+// fixLocalZone corrects the offset of zone-less date/times: parsetime stamps
+// them with a fixed snapshot of today's zone (e.g. EDT on a January date), so
+// reinterpret the wall clock in time.Local, which resolves the DST offset in
+// effect on that date; times that carry any other explicit zone are untouched
+func fixLocalZone(t time.Time) time.Time {
+	name, offset := t.Zone()
+	nowName, nowOffset := time.Now().Zone()
+	if name == nowName && offset == nowOffset {
+		return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.Local)
+	}
+	return t
+}
+
+// parseDateTime parses a date/time string with parsetime, correcting the
+// DST offset of zone-less strings via fixLocalZone
+func parseDateTime(source string) (time.Time, error) {
+	p, err := parsetime.NewParseTime()
+	if err != nil {
+		return time.Time{}, err
+	}
+	t, err := p.Parse(source)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return fixLocalZone(t), nil
+}
+
 // Reformat converts a date/time string into a specified format. The source can be:
 //   - A Unix timestamp (e.g., "1700265600")
 //   - A relative date (e.g., "yesterday", "now")
-//   - Any other date format parseable by parsetime
+//   - Any other parseable date format
 //
 // The outputFormat parameter uses strftime format specifiers, with additional
 // support for Unix seconds via '%s'.
@@ -103,18 +130,6 @@ func removeTrailingS(s string) string {
 //   - The time parser initialization fails
 func Reformat(source string, outputFormat string) (string, error) {
 	source = strings.TrimSpace(source)
-	if isPureIntegerAtoi(source) {
-		if source[0] == '-' {
-			return "", fmt.Errorf("timestamps can't be negative: %v", source)
-		}
-		t, err := unixStringToTime(source)
-		if err != nil {
-			return "", err
-		}
-		source = t.String()
-	} else {
-		source = ConvertRelativeDateToActual(source)
-	}
 
 	// creates a new Strftime instance
 	// outputFormat is a pattern string that follows strftime formatting
@@ -123,35 +138,43 @@ func Reformat(source string, outputFormat string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	p, err := parsetime.NewParseTime()
-	if err != nil {
-		return "", err
-	}
-	s, err := p.Parse(source)
-	if err != nil {
-		return "", err
 
+	var t time.Time
+	if isPureIntegerAtoi(source) {
+		if source[0] == '-' {
+			return "", fmt.Errorf("timestamps can't be negative: %v", source)
+		}
+		t, err = unixStringToTime(source)
+	} else {
+		t, err = parseDateTime(ConvertRelativeDateToActual(source))
 	}
-	return f.FormatString(s), nil
+	if err != nil {
+		return "", err
+	}
+	return f.FormatString(t), nil
 }
 
 // unixStringToTime converts a string containing a Unix timestamp to time.Time.
-// It accepts timestamps in both seconds (10 digits) and milliseconds (13 digits).
+// It accepts timestamps in seconds (up to 10 digits) and milliseconds (13 digits).
 // Returns the corresponding time.Time and any error encountered during conversion.
 //
-// If the input string is not a valid integer or is empty,
-// it returns a zero time.Time and an error.
+// If the input string is not a valid integer, is empty, or has an ambiguous
+// length (11, 12, or more than 13 digits), it returns a zero time.Time and an error.
 func unixStringToTime(timestamp string) (time.Time, error) {
-	unixTime, err := strconv.ParseInt(strings.TrimSpace(timestamp), 10, 64)
+	timestamp = strings.TrimSpace(timestamp)
+	unixTime, err := strconv.ParseInt(timestamp, 10, 64)
 	if err != nil {
 		return time.Time{}, err
 	}
 
-	if len(timestamp) == 13 {
+	switch {
+	case len(timestamp) <= 10:
+		return time.Unix(unixTime, 0), nil
+	case len(timestamp) == 13:
 		return time.UnixMilli(unixTime), nil
+	default:
+		return time.Time{}, fmt.Errorf("ambiguous timestamp length %d for %q: expected up to 10 digits (seconds) or exactly 13 (milliseconds)", len(timestamp), timestamp)
 	}
-
-	return time.Unix(unixTime, 0), nil
 }
 
 // isPureIntegerAtoi reports whether a string contains a valid base-10 integer.

--- a/DateTimeMate_test.go
+++ b/DateTimeMate_test.go
@@ -1,6 +1,35 @@
 package DateTimeMate
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestReformatWinterUnixSeconds(t *testing.T) {
+	// a zone-less winter date must convert to the unix timestamp using the
+	// local UTC offset in effect on that date, not the offset in effect today
+	correct, err := time.ParseInLocation("2006-01-02 15:04:05", "2024-01-01 00:00:00", time.Local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	computed, err := Reformat("2024-01-01 00:00:00", "%s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if computed != strconv.FormatInt(correct.Unix(), 10) {
+		t.Errorf("[computed: %v] != [correct: %v]", computed, correct.Unix())
+	}
+}
+
+func TestReformatAmbiguousTimestampLength(t *testing.T) {
+	// 11, 12, and 14+ digit integers are neither seconds nor milliseconds
+	for _, source := range []string{"12345678901", "123456789012", "12345678901234"} {
+		if _, err := Reformat(source, "%F"); err == nil {
+			t.Errorf("expected an error for timestamp %q, got nil", source)
+		}
+	}
+}
 
 func TestShrinkPeriod(t *testing.T) {
 	// explicitly define these here as a sanity check vs just iterating through abbrevMap

--- a/conv.go
+++ b/conv.go
@@ -110,10 +110,15 @@ func (conv *Conv) parseSource() (float64, error) {
 		if err != nil {
 			return 0, err
 		}
-		unit := strings.ToLower(removeTrailingS(parts[i+1]))
-		if seconds, ok := unitMap[unit]; ok {
-			totalSeconds += value * seconds
+		if i+1 >= len(parts) {
+			return 0, fmt.Errorf("missing unit after %q in: %s", parts[i], conv.Source)
 		}
+		unit := strings.ToLower(removeTrailingS(parts[i+1]))
+		seconds, ok := unitMap[unit]
+		if !ok {
+			return 0, fmt.Errorf("unknown source unit: %q", parts[i+1])
+		}
+		totalSeconds += value * seconds
 	}
 	return totalSeconds, nil
 }
@@ -139,9 +144,9 @@ func (conv *Conv) parseSource() (float64, error) {
 func (conv *Conv) formatTarget(seconds float64, units []string) string {
 	result := ""
 	for i, unit := range units {
-		unitInSeconds := unitMap[strings.TrimSuffix(unit, "s")]
+		unit = strings.ToLower(removeTrailingS(unit))
+		unitInSeconds := unitMap[unit]
 		value := seconds / unitInSeconds
-		unit = removeTrailingS(unit)
 
 		if conv.Decimals > 0 && i == len(units)-1 {
 			if value < 0 { // guard against float underflow producing "-0.00"
@@ -167,7 +172,27 @@ func (conv *Conv) formatTarget(seconds float64, units []string) string {
 		result += fmt.Sprintf("%d %s ", intValue, unit)
 		seconds -= float64(intValue) * unitInSeconds
 	}
+	if result == "" {
+		// every unit truncated to zero, so emit zero of the smallest unit
+		// instead of an empty string
+		result = fmt.Sprintf("0 %ss", strings.ToLower(removeTrailingS(units[len(units)-1])))
+	}
 	return strings.TrimSpace(result)
+}
+
+// isLongFormDuration reports whether the fields form alternating
+// amount/unit pairs, such as "1 hour 30 minutes"; anything else, including
+// brief formats with spaces such as "1h 30m", needs brief expansion
+func isLongFormDuration(fields []string) bool {
+	if len(fields) == 0 || len(fields)%2 != 0 {
+		return false
+	}
+	for i := 0; i < len(fields); i += 2 {
+		if _, err := strconv.ParseFloat(fields[i], 64); err != nil {
+			return false
+		}
+	}
+	return true
 }
 
 // expandBriefSourceDuration expands a brief period into a long period format
@@ -249,13 +274,13 @@ func (conv *Conv) ConvertDuration() (string, error) {
 		conv.Source = s
 		isNegativeDuration = true
 	}
-	fields := strings.Fields(conv.Source)
-	if len(fields) == 1 {
+	if !isLongFormDuration(strings.Fields(conv.Source)) {
 		// brief format is being used so convert to long duration format
-		conv.Source, err = expandBriefSourceDuration(conv.Source)
+		expandedSource, err := expandBriefSourceDuration(conv.Source)
 		if nil != err {
-			return "", err
+			return "", fmt.Errorf("invalid source duration %q: %v", conv.Source, err)
 		}
+		conv.Source = expandedSource
 	}
 	seconds, err := conv.parseSource()
 	if err != nil {
@@ -263,13 +288,18 @@ func (conv *Conv) ConvertDuration() (string, error) {
 	}
 	targetUnits := strings.Fields(conv.Target)
 	if len(targetUnits) == 1 {
-		_, ok := unitMap[removeTrailingS(conv.Target)]
+		_, ok := unitMap[strings.ToLower(removeTrailingS(conv.Target))]
 		if !ok {
 			// brief format is being used so convert to long duration format
 			targetUnits, err = expandBriefTargetDuration(conv.Target)
 			if nil != err {
 				return "", err
 			}
+		}
+	}
+	for _, unit := range targetUnits {
+		if _, ok := unitMap[strings.ToLower(removeTrailingS(unit))]; !ok {
+			return "", fmt.Errorf("unknown target unit: %q", unit)
 		}
 	}
 	result := conv.formatTarget(seconds, targetUnits)

--- a/conv_test.go
+++ b/conv_test.go
@@ -94,6 +94,37 @@ func TestConvDecimalsOutOfRange(t *testing.T) {
 	}
 }
 
+func TestConvInvalidInput(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ source, target string }{
+		{"1 hour 2", "hours"},           // dangling amount with no unit (used to panic)
+		{"1 fortnight", "hours"},        // unknown source unit (used to output nothing)
+		{"90 minutes", "hours bananas"}, // unknown target unit (used to divide by zero)
+		{"90 minutes", "fortnights"},    // unknown single target unit
+	}
+	for _, c := range cases {
+		conv := NewConv(ConvWithSource(c.source), ConvWithTarget(c.target))
+		if _, err := conv.ConvertDuration(); err == nil {
+			t.Errorf("expected an error for source %q target %q, got nil", c.source, c.target)
+		}
+	}
+}
+
+func TestConvZeroResult(t *testing.T) {
+	t.Parallel()
+	// a result that truncates to zero emits zero of the smallest unit
+	// instead of an empty string
+	testConv(t, "3599 seconds", "hours", false, "0 hours")
+	testConv(t, "3599 seconds", "hours", true, "0h")
+	testConv(t, "0 seconds", "days hours", false, "0 hours")
+}
+
+func TestConvBriefWithSpaces(t *testing.T) {
+	t.Parallel()
+	testConv(t, "1h 30m", "minutes", false, "90 minutes")
+	testConv(t, "1Y 3W 4D", "days", false, "390 days")
+}
+
 func TestConvHoursMinutesSeconds(t *testing.T) {
 	t.Parallel()
 	source := "386 hours 24 minutes 36 seconds"

--- a/diff.go
+++ b/diff.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/golang-module/carbon/v2"
 	"github.com/hako/durafmt"
-	"github.com/jftuga/parsetime"
 	"time"
 )
 
@@ -46,39 +45,30 @@ func (diff *Diff) String() string {
 	return fmt.Sprintf("Start:%v End:%v Brief:%v", diff.Start, diff.End, diff.Brief)
 }
 
+// parseDiffTime parses one side of a diff: 10-digit (seconds) and 13-digit
+// (milliseconds) integers are treated as Unix timestamps; anything else is
+// parsed with carbon first, falling back to parsetime if carbon fails
+func parseDiffTime(source string) (time.Time, error) {
+	if isPureIntegerAtoi(source) && (len(source) == 10 || len(source) == 13) {
+		return unixStringToTime(source)
+	}
+	converted := ConvertRelativeDateToActual(source)
+	if c := carbon.Parse(converted); c.Error == nil {
+		return c.StdTime(), nil
+	}
+	return parseDateTime(converted)
+}
+
 // CalculateDiff return the time difference and also set dt.Diff
 // first try to parse with carbon, fallback to parsing with parsetime if carbon fails to parse
 func (diff *Diff) CalculateDiff() (string, time.Duration, error) {
-	var start, end time.Time
-
-	alpha := carbon.Parse(ConvertRelativeDateToActual(diff.Start))
-	if alpha.Error != nil {
-		// fmt.Println("alpha:", alpha.Error)
-		p, err := parsetime.NewParseTime()
-		if err != nil {
-			return "", 0, err
-		}
-		start, err = p.Parse(diff.Start)
-		if err != nil {
-			return "", 0, err
-		}
-	} else {
-		start = alpha.StdTime()
+	start, err := parseDiffTime(diff.Start)
+	if err != nil {
+		return "", 0, err
 	}
-
-	omega := carbon.Parse(ConvertRelativeDateToActual(diff.End))
-	if omega.Error != nil {
-		// fmt.Println("omega:", omega.Error)
-		p, err := parsetime.NewParseTime()
-		if err != nil {
-			return "", 0, err
-		}
-		end, err = p.Parse(diff.End)
-		if err != nil {
-			return "", 0, err
-		}
-	} else {
-		end = omega.StdTime()
+	end, err := parseDiffTime(diff.End)
+	if err != nil {
+		return "", 0, err
 	}
 
 	yearDiff := end.Year() - start.Year()

--- a/diff_test.go
+++ b/diff_test.go
@@ -87,6 +87,13 @@ func TestDiffMilliSeconds(t *testing.T) {
 	testDiffStartEnd(t, start, end, true, correctBrief)
 }
 
+func TestDiffUnixTimestamps(t *testing.T) {
+	t.Parallel()
+	// 10-digit timestamps are seconds; 13-digit timestamps are milliseconds
+	testDiffStartEnd(t, "1700000000", "1700003600", false, "1 hour")
+	testDiffStartEnd(t, "1700000000000", "1700000000500", false, "500 milliseconds")
+}
+
 func TestDiffYearOverflow(t *testing.T) {
 	t.Parallel()
 	diff := NewDiff(

--- a/dur.go
+++ b/dur.go
@@ -3,9 +3,8 @@ package DateTimeMate
 import (
 	"fmt"
 	"github.com/golang-module/carbon/v2"
-	"github.com/jftuga/parsetime"
 	"github.com/lestrrat-go/strftime"
-	"os"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -30,9 +29,14 @@ type Dur struct {
 type OptionsDur func(*Dur)
 
 const (
-	expanded  string = `(\d+)\s(years?|weeks?|days?|hours?|minutes?|seconds?|milliseconds?|microseconds?|nanoseconds?)`
-	wordsOnly string = `\b[a-zA-Z]+\b`
-	hintMsg   string = "Hint: duplicate durations not allowed; dates in uppercase; times in lowercase"
+	// a period is a series of amount/unit pairs; the amount must start at the
+	// beginning of the string or after whitespace so that a fractional amount
+	// such as "1.5" can never be partially matched as "5"
+	expanded string = `(?:^|\s)(\d+(?:\.\d+)?)\s(years?|weeks?|days?|hours?|minutes?|seconds?|milliseconds?|microseconds?|nanoseconds?)`
+	hintMsg  string = "Hint: duplicate durations not allowed; dates in uppercase; times in lowercase"
+
+	// maxUntilIterations is a backstop against unbounded output from the until option
+	maxUntilIterations = 1_000_000
 )
 
 var carbonFuncs = map[string]interface{}{
@@ -45,6 +49,20 @@ var carbonFuncs = map[string]interface{}{
 	"millisecond": [2]interface{}{carbon.Carbon.AddMilliseconds, carbon.Carbon.SubMilliseconds},
 	"microsecond": [2]interface{}{carbon.Carbon.AddMicroseconds, carbon.Carbon.SubMicroseconds},
 	"nanosecond":  [2]interface{}{carbon.Carbon.AddNanoseconds, carbon.Carbon.SubNanoseconds},
+}
+
+// unitNanoseconds is used to apply the fractional part of an amount, so the
+// calendar-aware carbon functions still handle the integer part
+var unitNanoseconds = map[string]float64{
+	"year":        365.25 * 24 * float64(time.Hour),
+	"week":        7 * 24 * float64(time.Hour),
+	"day":         24 * float64(time.Hour),
+	"hour":        float64(time.Hour),
+	"minute":      float64(time.Minute),
+	"second":      float64(time.Second),
+	"millisecond": float64(time.Millisecond),
+	"microsecond": float64(time.Microsecond),
+	"nanosecond":  1,
 }
 
 var expandedRegexp = regexp.MustCompile(expanded)
@@ -101,164 +119,155 @@ func (dur *Dur) Sub() ([]string, error) {
 // addOrSub - calculates a date/time when given a starting date/time and a duration
 // also handle: the repeat and until options, relative dates, output formatting
 func (dur *Dur) addOrSub(op int) ([]string, error) {
+	if dur.Repeat < 0 {
+		return nil, fmt.Errorf("repeat must not be negative: %d", dur.Repeat)
+	}
 	if dur.Repeat > 0 && dur.Until != "" {
 		return nil, fmt.Errorf("repeat & until are mutually exclusive")
 	}
 
-	var all []string
-	var err error
-	if dur.Repeat == 0 && dur.Until == "" {
-		var c string
-		c, err = calculate(dur.From, dur.Period, op)
+	f, err := parseDateTime(ConvertRelativeDateToActual(dur.From))
+	if err != nil {
+		return nil, err
+	}
+	from := carbon.CreateFromStdTime(f)
+	if from.Error != nil {
+		return nil, from.Error
+	}
+	periodMatches, err := parsePeriod(dur.Period)
+	if err != nil {
+		return nil, err
+	}
+
+	var all []carbon.Carbon
+	switch {
+	case dur.Repeat == 0 && dur.Until == "":
+		to, err := applyPeriod(from, periodMatches, op)
 		if err != nil {
 			return nil, err
 		}
-		all = []string{c}
-	} else if dur.Repeat > 0 && dur.Until == "" {
-		from := dur.From
+		all = append(all, to)
+	case dur.Repeat > 0:
+		to := from
 		for i := 0; i < dur.Repeat; i++ {
-			from, err = calculate(from, dur.Period, op)
+			to, err = applyPeriod(to, periodMatches, op)
 			if err != nil {
 				return nil, err
 			}
-			all = append(all, from)
+			all = append(all, to)
 		}
-	} else if dur.Repeat == 0 && dur.Until != "" {
-		var f, u time.Time
-		var err error
-
-		until := ConvertRelativeDateToActual(dur.Until)
-		p, err := parsetime.NewParseTime()
+	default: // until
+		u, err := parseDateTime(ConvertRelativeDateToActual(dur.Until))
 		if err != nil {
 			return nil, err
 		}
-		u, err = p.Parse(until)
-		if err != nil {
-			return nil, err
-		}
-
-		from := ConvertRelativeDateToActual(dur.From)
-		for {
-			from, err = calculate(from, dur.Period, op)
+		to := from
+		for i := 0; ; i++ {
+			if i >= maxUntilIterations {
+				return nil, fmt.Errorf("until would produce more than %d results", maxUntilIterations)
+			}
+			next, err := applyPeriod(to, periodMatches, op)
 			if err != nil {
 				return nil, err
 			}
-
-			p, err := parsetime.NewParseTime()
-			if err != nil {
-				return nil, err
+			if next.StdTime().Equal(to.StdTime()) {
+				return nil, fmt.Errorf("duration %q does not advance toward the until date/time", dur.Period)
 			}
-			f, err = p.Parse(from)
-			if err != nil {
-				return nil, err
-			}
-
+			to = next
 			if Add == op {
-				if f.After(u) {
+				if to.StdTime().After(u) {
 					break
 				}
 			} else {
-				if f.Before(u) {
+				if to.StdTime().Before(u) {
 					break
 				}
 			}
-			all = append(all, from)
+			all = append(all, to)
 		}
 	}
+	return dur.renderResults(all)
+}
 
-	if len(dur.OutputFormat) > 0 && len(all) > 0 {
-		var allWithFormat []string
-		for _, a := range all {
-			formatted, err := dur.setOutputFormat(a)
-			if err != nil {
-				return nil, err
-			}
-			allWithFormat = append(allWithFormat, formatted)
+// renderResults converts computed date/times to strings, applying the
+// optional strftime output format which also supports the unix time %s modifier
+func (dur *Dur) renderResults(all []carbon.Carbon) ([]string, error) {
+	rendered := make([]string, 0, len(all))
+	if len(dur.OutputFormat) == 0 {
+		for _, c := range all {
+			rendered = append(rendered, c.ToString())
 		}
-		return allWithFormat, nil
+		return rendered, nil
 	}
-	return all, nil
+	f, err := strftime.New(dur.OutputFormat, strftime.WithUnixSeconds('s'))
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range all {
+		rendered = append(rendered, f.FormatString(c.StdTime()))
+	}
+	return rendered, nil
 }
 
-// setOutputFormat use a strftime format string for the output date/time
-func (dur *Dur) setOutputFormat(arg string) (string, error) {
-	f, err := strftime.New(dur.OutputFormat)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-	p, err := parsetime.NewParseTime()
-	if err != nil {
-		return "", err
-	}
-	s, err := p.Parse(arg)
-	if err != nil {
-		return "", err
-	}
-	output := f.FormatString(s)
-	return output, nil
-}
-
-// calculate given a from date and period duration, compute a new date/time
-// when index==0, then add; when index==1, then subtract
-func calculate(from, period string, index int) (string, error) {
-	periodMatches := expandedRegexp.FindAllStringSubmatch(period, -1)
-	if len(periodMatches) == 0 {
+// parsePeriod parses a period in either long or brief format into
+// (amount, unit) pairs, erroring if any part of the period is not understood
+func parsePeriod(period string) ([][2]string, error) {
+	indexes := expandedRegexp.FindAllStringSubmatchIndex(period, -1)
+	if len(indexes) == 0 {
 		// brief format is being used so first expand it to the long format
-		period, err := expandPeriod(period)
+		var err error
+		period, err = expandPeriod(period)
 		if nil != err {
-			return "", fmt.Errorf("%v", err)
+			return nil, err
 		}
-		periodMatches = expandedRegexp.FindAllStringSubmatch(period, -1)
-		if len(periodMatches) == 0 {
-			return "", fmt.Errorf("[validatePeriod] Invalid duration: %s", period)
+		indexes = expandedRegexp.FindAllStringSubmatchIndex(period, -1)
+		if len(indexes) == 0 {
+			return nil, fmt.Errorf("[parsePeriod] Invalid duration: %s", period)
 		}
 	}
 
-	from = ConvertRelativeDateToActual(from)
-	p, err := parsetime.NewParseTime()
-	if err != nil {
-		return "", err
+	// every character must belong to a match, otherwise part of the
+	// period, such as the "2m" in "1 hour 2m", would be silently ignored
+	var matches [][2]string
+	var leftover strings.Builder
+	prev := 0
+	for _, m := range indexes {
+		leftover.WriteString(period[prev:m[0]])
+		prev = m[1]
+		matches = append(matches, [2]string{period[m[2]:m[3]], period[m[4]:m[5]]})
 	}
-	f, err := p.Parse(from)
-	if err != nil {
-		return "", err
+	leftover.WriteString(period[prev:])
+	if remains := strings.TrimSpace(leftover.String()); remains != "" {
+		return nil, fmt.Errorf("[parsePeriod] Invalid duration %q in: %s. %s", remains, period, hintMsg)
 	}
-
-	to := carbon.CreateFromStdTime(f)
-	if to.Error != nil {
-		return "", to.Error
-	}
-	err = validatePeriod(period)
-	if err != nil {
-		return "", err
-	}
-
-	for i := range periodMatches {
-		amount := periodMatches[i][1]
-		num, err := strconv.Atoi(amount)
-		if err != nil {
-			return "", err
-		}
-		word := periodMatches[i][2]
-		to = carbonFuncs[removeTrailingS(word)].([2]interface{})[index].(func(carbon.Carbon, int) carbon.Carbon)(to, num)
-		// fmt.Printf("    to: %v | %v | %v\n", num, word, to)
-	}
-	return to.ToString(), nil
+	return matches, nil
 }
 
-// validatePeriod ensure all words in "period" are a valid time duration
-func validatePeriod(period string) error {
-	wordsOnlyRe := regexp.MustCompile(wordsOnly)
-	matches := wordsOnlyRe.FindAllString(period, -1)
-	for _, word := range matches {
-		// fmt.Println("word:", word)
-		_, ok := carbonFuncs[removeTrailingS(word)]
-		if !ok {
-			return fmt.Errorf("[validatePeriod] Invalid period: %s", word)
+// applyPeriod applies each (amount, unit) pair of a parsed period to a date/time
+// when index==0, then add; when index==1, then subtract
+// the integer part of an amount uses carbon's calendar-aware functions; any
+// fractional part is applied as nanoseconds
+func applyPeriod(to carbon.Carbon, periodMatches [][2]string, index int) (carbon.Carbon, error) {
+	for _, match := range periodMatches {
+		amount, word := match[0], removeTrailingS(match[1])
+		value, err := strconv.ParseFloat(amount, 64)
+		if err != nil {
+			return to, err
+		}
+		if value > math.MaxInt32 {
+			return to, fmt.Errorf("amount too large: %s", amount)
+		}
+		whole, frac := math.Modf(value)
+		to = carbonFuncs[word].([2]interface{})[index].(func(carbon.Carbon, int) carbon.Carbon)(to, int(whole))
+		if frac > 0 {
+			ns := int(math.Round(frac * unitNanoseconds[word]))
+			to = carbonFuncs["nanosecond"].([2]interface{})[index].(func(carbon.Carbon, int) carbon.Carbon)(to, ns)
+		}
+		if to.Error != nil {
+			return to, to.Error
 		}
 	}
-	return nil
+	return to, nil
 }
 
 // expandPeriod convert a brief style period into a long period

--- a/dur_test.go
+++ b/dur_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/golang-module/carbon/v2"
 	"strings"
 	"testing"
+	"time"
 )
 
 func testDurAddSubContains(t *testing.T, from, period, correctAdd, correctSub string) {
@@ -111,6 +112,78 @@ func testDurSubUntil(t *testing.T, from, until, periodPast string, correctSub []
 		if !strings.Contains(past[i], correctSub[i]) {
 			t.Errorf("[from: %v] [computed: %v] does not contain: [correct: %v]", from, past[i], correctSub[i])
 		}
+	}
+}
+
+func TestDurFractionalPeriod(t *testing.T) {
+	t.Parallel()
+	from := "2024-01-01 00:00:00"
+	period := "1.5 hours"
+	briefPeriod := "1.5h"
+	correctAdd := "2024-01-01 01:30:00"
+	correctSub := "2023-12-31 22:30:00"
+	testDurAddSubContains(t, from, period, correctAdd, correctSub)
+	testDurAddSubContains(t, from, briefPeriod, correctAdd, correctSub)
+}
+
+func TestDurInvalidPeriodText(t *testing.T) {
+	t.Parallel()
+	// no part of a period may be silently ignored
+	for _, period := range []string{"1 hour 2", "1 hour 2m", "1 hour bananas", "1.5.2 hours"} {
+		dur := NewDur(DurWithFrom("2024-01-01"), DurWithDur(period))
+		if _, err := dur.Add(); err == nil {
+			t.Errorf("expected an error for period %q, got nil", period)
+		}
+	}
+}
+
+func TestDurNegativeRepeat(t *testing.T) {
+	t.Parallel()
+	dur := NewDur(DurWithFrom("2024-01-01"), DurWithDur("1 hour"), DurWithRepeat(-1))
+	if _, err := dur.Add(); err == nil {
+		t.Error("expected an error for a negative repeat, got nil")
+	}
+}
+
+func TestDurZeroPeriodUntil(t *testing.T) {
+	t.Parallel()
+	// a period that does not advance must error instead of looping forever
+	dur := NewDur(DurWithFrom("2024-01-01"), DurWithDur("0 minutes"), DurWithUntil("2024-01-02"))
+	if _, err := dur.Add(); err == nil {
+		t.Error("expected an error for a zero-length period with until, got nil")
+	}
+}
+
+func TestDurSubSecondRepeat(t *testing.T) {
+	t.Parallel()
+	// sub-second precision must survive repeated application
+	from := "2024-01-01 00:00:00"
+	period := "500ms"
+	repeat := 3
+	allCorrectAdd := []string{"2024-01-01 00:00:00.5 ", "2024-01-01 00:00:01 ", "2024-01-01 00:00:01.5 "}
+	allCorrectSub := []string{"2023-12-31 23:59:59.5 ", "2023-12-31 23:59:59 ", "2023-12-31 23:59:58.5 "}
+	testDurAddSubWithRepeat(t, from, period, allCorrectAdd, allCorrectSub, repeat)
+}
+
+func TestDurWinterTimezoneOffset(t *testing.T) {
+	t.Parallel()
+	// a zone-less date must resolve with the local UTC offset in effect on
+	// that date, not the offset in effect today
+	dur := NewDur(DurWithFrom("2024-01-15 12:00:00"), DurWithDur("1 hour"))
+	future, err := dur.Add()
+	if err != nil {
+		t.Fatal(err)
+	}
+	computed, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", future[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	correct, err := time.ParseInLocation("2006-01-02 15:04:05", "2024-01-15 13:00:00", time.Local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !computed.Equal(correct) {
+		t.Errorf("[computed: %v] != [correct: %v]", computed, correct)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR is the result of a systematic bug hunt across all four sub-commands. It fixes 14 verified bugs: one crash, one infinite loop, seven silent wrong-result bugs, and five unexpected-behavior issues. None of these were covered by the existing test suite; 12 new regression tests were added and all 74 tests now pass under UTC, America/New_York, and Australia/Sydney timezones.

## Crashes and hangs

- `dtmate conv "1 hour 2" h` panicked with an index-out-of-range error because `parseSource` read the unit following an amount without a bounds check. It now returns a clear error.
- `dtmate dur now 0m -a -u tomorrow` looped forever while allocating memory, because a zero-length period never advances past the `--until` date. It now errors with "duration does not advance toward the until date/time", and a 1,000,000-iteration backstop guards against pathological cases such as nanosecond periods spanning days.

## Silent wrong results

- `dtmate dur now 1.5h -a` silently added 5 hours: the period regex `(\d+)\s(unit)` matched the "5 hours" inside the expanded "1.5 hours" and discarded the "1.". The regex is now anchored and accepts fractional amounts, which are fully supported: the integer part uses carbon's calendar-aware arithmetic and the fractional part is applied as nanoseconds, matching the fractional support `conv` already had.
- `dtmate dur now "1 hour 2m" -a` silently ignored the "2m" because the validation regex could not see letters glued to digits. Period parsing now requires every character to belong to a recognized amount/unit pair and errors on any leftover text.
- Zone-less date strings were stamped with a snapshot of *today's* UTC offset, so `dtmate fmt "2024-01-01 00:00:00" %s` run during daylight saving time was off by 3600 seconds, and `dur` printed EDT on January dates. A new `fixLocalZone` helper reinterprets the wall clock in `time.Local` so each date resolves the DST offset actually in effect on that date. The root cause is in the upstream parsetime library and is documented separately for an upstream fix.
- `dtmate diff 1700000000 1700003600` printed "3 microseconds" instead of "1 hour" because carbon misparses integer strings. `diff` now recognizes 10-digit (seconds) and 13-digit (milliseconds) arguments as Unix timestamps.
- `dtmate conv "1 fortnight" hours` printed an empty line and exited 0; unknown source units now error.
- `dtmate conv 90m "hours bananas"` printed "1 hour 9223372036854775807 bananas" due to a division by zero on the unvalidated target unit; unknown target units now error, and target units are case-insensitive.
- `dtmate dur "2024-01-01 00:00:00" 500ms -a -r 3` produced .5, .500000005, 1.000000005 instead of .5, 1.0, 1.5 because each repeat iteration round-tripped the result through a string and reparsed it. Results now stay as `carbon.Carbon` values across `--repeat`/`--until` iterations and are only formatted at output time.

## Unexpected behavior

- Conversions that truncated to zero (`conv 3599s h`, `diff now today -c s`) printed an empty line; they now print zero of the smallest requested unit, e.g. "0 hours" or "0h" with `--brief`.
- `dur --format` now supports `%s` (Unix seconds), matching `fmt`; the formatting path also no longer calls `os.Exit` from library code.
- `dur --repeat` with a negative count silently printed nothing; it now errors.
- `conv` now accepts the brief-with-spaces form documented in `--help-all`, so `conv "1h 30m" m` returns "90 minutes" instead of a cryptic ParseFloat error.
- `fmt` with an 11, 12, or 14+ digit integer produced a nonsense date; these ambiguous lengths now error while up to 10 digits (seconds) and exactly 13 digits (milliseconds) continue to work.

## Testing

- 12 new regression tests cover every fixed bug class: fractional periods, invalid period text, negative repeat, zero-period until, sub-second repeat precision, winter timezone offsets, Unix timestamp diffs, ambiguous timestamp lengths, unknown units, zero-valued results, and brief-with-spaces conversion.
- `go test ./...` passes (74 tests) under TZ=UTC, TZ=America/New_York, and TZ=Australia/Sydney; `go vet ./...` is clean.
- All README `--examples` commands and the `cmd/example` program were re-run to verify no regressions.
