### PR TITLE
Emit a clear error for negative durations in `dur`

### DIFF
--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -21,7 +21,7 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.8.0"
+	ModVersion string = "1.8.1"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 

--- a/cmd/dtmate/cmd/dur.go
+++ b/cmd/dtmate/cmd/dur.go
@@ -40,6 +40,22 @@ func init() {
 	durCmd.MarkFlagsOneRequired("add", "sub")
 	durCmd.MarkFlagsMutuallyExclusive("add", "sub")
 	durCmd.MarkFlagsMutuallyExclusive("repeat", "until")
+	durCmd.SetFlagErrorFunc(negativeDurationHint)
+}
+
+// negativeDurationHint rewrites the cryptic pflag error produced when a user
+// passes a negative-looking duration (e.g. "-1h") to 'dur' into a clear message
+// directing them to -s/--sub. Any other flag error is returned unchanged.
+func negativeDurationHint(cmd *cobra.Command, err error) error {
+	const marker = "unknown shorthand flag: '"
+	msg := err.Error()
+	if i := strings.Index(msg, marker); i != -1 {
+		c := msg[i+len(marker)]
+		if c >= '0' && c <= '9' {
+			return fmt.Errorf("'dur' does not accept negative durations.\nUse -s/--sub to subtract, e.g.:\n  dtmate dur now 1h -s\n")
+		}
+	}
+	return err
 }
 
 func outputDur(from, duration, until, format string, repeat int) {

--- a/cmd/dtmate/cmd/dur_test.go
+++ b/cmd/dtmate/cmd/dur_test.go
@@ -1,0 +1,45 @@
+// dur_test.go verifies the CLI-layer helpers for the 'dur' sub-command.
+// It covers negativeDurationHint, which turns the cryptic pflag "unknown
+// shorthand flag" error (produced when a user passes a negative-looking
+// duration such as -1h) into a clear message directing them to -s/--sub, while
+// leaving every other flag error untouched.
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestNegativeDurationHint(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		rewrite  bool   // true when the error should be replaced with the hint
+		contains string // substring the returned error must contain
+	}{
+		{name: "brief negative duration", err: errors.New("unknown shorthand flag: '1' in -1h"), rewrite: true, contains: "-s/--sub"},
+		{name: "fractional negative duration", err: errors.New("unknown shorthand flag: '1' in -1.5h"), rewrite: true, contains: "-s/--sub"},
+		{name: "verbose negative duration", err: errors.New("unknown shorthand flag: '9' in -90m"), rewrite: true, contains: "-s/--sub"},
+		{name: "unknown letter flag", err: errors.New("unknown shorthand flag: 'x' in -x"), rewrite: false},
+		{name: "unrelated error", err: errors.New("some other error"), rewrite: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := negativeDurationHint(nil, tt.err)
+			if !tt.rewrite {
+				if got != tt.err {
+					t.Fatalf("expected error to pass through unchanged, got: %v", got)
+				}
+				return
+			}
+			if got == tt.err {
+				t.Fatal("expected error to be rewritten, got the original")
+			}
+			if !strings.Contains(got.Error(), tt.contains) {
+				t.Errorf("rewritten error %q does not contain %q", got.Error(), tt.contains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Running `dtmate dur now -1h -a` previously failed with a cryptic, pflag-internal message — `Error: unknown shorthand flag: '1' in -1h` — because the `-1h` token is intercepted as a bundle of shorthand flags before it ever reaches the duration logic, leaving the user staring at an error about a flag `1` they never typed.

This PR intercepts that specific parse failure via cobra's `SetFlagErrorFunc` on `durCmd` and, when the offending shorthand character is a digit (the negative-number/duration case), rewrites it to a clear, actionable message: `'dur' does not accept negative durations. Use -s/--sub to subtract, e.g.: dtmate dur now 1h -s`. Every other flag error — including a genuine unknown letter flag like `-x` — passes through unchanged.

Negative durations are intentionally not made functional in `dur`. The sign is already carried by the `-a`/`--add` and `-s`/`--sub` flags, so `dur X -1h -a` would be a purely redundant spelling of the already-working `dur X 1h -s`, and allowing it would introduce a double-negative footgun where `-1h -s` means add. This is deliberately different from `conv`, where a leading `-` is the only way to express a negative result and is therefore genuinely supported.

Changes: added `negativeDurationHint` plus its registration in `cmd/dtmate/cmd/dur.go`; added a table-driven `TestNegativeDurationHint` in the new `cmd/dtmate/cmd/dur_test.go` (mirroring the existing `TestParseConvArgs` style); bumped `ModVersion` to `1.8.1`.

Verification: `go build ./...` and `go test ./...` both pass. Manually confirmed `dur now -1h -a` shows the new message, `dur ... 1h -s` and `dur ... 1h -a` are unchanged, and `dur now 1h -x` still yields the normal unknown-flag error.

Fixes: https://github.com/jftuga/DateTimeMate/issues/24
