### PR TITLE
Fix case-insensitive unit parsing and empty-target panic in conv; add tests from issue #18

### DIFF
--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -21,7 +21,7 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.8.1"
+	ModVersion string = "1.8.2"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 

--- a/conv.go
+++ b/conv.go
@@ -88,6 +88,13 @@ func (conv *Conv) String() string {
 	return fmt.Sprintf("Source:%v Target:%v Brief:%v Decimals:%v", conv.Source, conv.Target, conv.Brief, conv.Decimals)
 }
 
+// normalizeUnit lowercases a unit name and strips a plural trailing "s"
+// so that forms such as "DAYS", "Days", and "days" all match the
+// singular lowercase keys used in unitMap
+func normalizeUnit(unit string) string {
+	return removeTrailingS(strings.ToLower(unit))
+}
+
 // parseSource parses the Source field of the Conv struct
 // and converts it to a total number of seconds.
 //
@@ -113,7 +120,7 @@ func (conv *Conv) parseSource() (float64, error) {
 		if i+1 >= len(parts) {
 			return 0, fmt.Errorf("missing unit after %q in: %s", parts[i], conv.Source)
 		}
-		unit := strings.ToLower(removeTrailingS(parts[i+1]))
+		unit := normalizeUnit(parts[i+1])
 		seconds, ok := unitMap[unit]
 		if !ok {
 			return 0, fmt.Errorf("unknown source unit: %q", parts[i+1])
@@ -144,7 +151,7 @@ func (conv *Conv) parseSource() (float64, error) {
 func (conv *Conv) formatTarget(seconds float64, units []string) string {
 	result := ""
 	for i, unit := range units {
-		unit = strings.ToLower(removeTrailingS(unit))
+		unit = normalizeUnit(unit)
 		unitInSeconds := unitMap[unit]
 		value := seconds / unitInSeconds
 
@@ -175,7 +182,7 @@ func (conv *Conv) formatTarget(seconds float64, units []string) string {
 	if result == "" {
 		// every unit truncated to zero, so emit zero of the smallest unit
 		// instead of an empty string
-		result = fmt.Sprintf("0 %ss", strings.ToLower(removeTrailingS(units[len(units)-1])))
+		result = fmt.Sprintf("0 %ss", normalizeUnit(units[len(units)-1]))
 	}
 	return strings.TrimSpace(result)
 }
@@ -287,8 +294,11 @@ func (conv *Conv) ConvertDuration() (string, error) {
 		return "", err
 	}
 	targetUnits := strings.Fields(conv.Target)
+	if len(targetUnits) == 0 {
+		return "", fmt.Errorf("no target units specified")
+	}
 	if len(targetUnits) == 1 {
-		_, ok := unitMap[strings.ToLower(removeTrailingS(conv.Target))]
+		_, ok := unitMap[normalizeUnit(conv.Target)]
 		if !ok {
 			// brief format is being used so convert to long duration format
 			targetUnits, err = expandBriefTargetDuration(conv.Target)
@@ -298,7 +308,7 @@ func (conv *Conv) ConvertDuration() (string, error) {
 		}
 	}
 	for _, unit := range targetUnits {
-		if _, ok := unitMap[strings.ToLower(removeTrailingS(unit))]; !ok {
+		if _, ok := unitMap[normalizeUnit(unit)]; !ok {
 			return "", fmt.Errorf("unknown target unit: %q", unit)
 		}
 	}

--- a/conv_test.go
+++ b/conv_test.go
@@ -101,6 +101,10 @@ func TestConvInvalidInput(t *testing.T) {
 		{"1 fortnight", "hours"},        // unknown source unit (used to output nothing)
 		{"90 minutes", "hours bananas"}, // unknown target unit (used to divide by zero)
 		{"90 minutes", "fortnights"},    // unknown single target unit
+		{"1 month", "days"},             // months are deliberately unsupported; lengths vary
+		{"", "hours"},                   // empty source
+		{"abc days", "hours"},           // invalid numeric amount
+		{"15", "hours"},                 // bare number with no unit
 	}
 	for _, c := range cases {
 		conv := NewConv(ConvWithSource(c.source), ConvWithTarget(c.target))
@@ -108,6 +112,34 @@ func TestConvInvalidInput(t *testing.T) {
 			t.Errorf("expected an error for source %q target %q, got nil", c.source, c.target)
 		}
 	}
+}
+
+func TestConvEmptyTarget(t *testing.T) {
+	t.Parallel()
+	// an empty or whitespace-only target used to panic with an
+	// index-out-of-range error instead of returning an error
+	for _, target := range []string{"", "   "} {
+		conv := NewConv(ConvWithSource("90 minutes"), ConvWithTarget(target))
+		if _, err := conv.ConvertDuration(); err == nil {
+			t.Errorf("expected an error for empty target %q, got nil", target)
+		}
+	}
+}
+
+func TestConvCaseInsensitiveUnits(t *testing.T) {
+	t.Parallel()
+	// long-form units are case-insensitive; uppercase plurals such as
+	// "DAYS" used to fail because the trailing "S" was not stripped
+	testConv(t, "1 DAYS", "hours", false, "24 hours")
+	testConv(t, "1 Week 2 DAYS", "days", false, "9 days")
+	testConv(t, "1 DaY 2 houRS", "hours", false, "26 hours")
+	testConv(t, "90 minutes", "HOURS", false, "1 hour")
+}
+
+func TestConvMixedSignSource(t *testing.T) {
+	t.Parallel()
+	// a negative amount mid-string subtracts from the total
+	testConv(t, "1 year -30 days", "days", false, "335 days")
 }
 
 func TestConvZeroResult(t *testing.T) {


### PR DESCRIPTION
## Summary

Triaging the test proposals in issue #18 against v1.8.1 surfaced two real bugs in the `conv` sub-command, both fixed here with regression tests. The remaining high-value test cases from the issue are also added, while proposals that duplicated existing coverage or depended on float-precision-fragile exact output were intentionally skipped.

## Bug 1: uppercase-plural units rejected

Long-form units are documented as case-insensitive, but `1 DAYS`, `1 HOURS`, and `1 Week 2 DAYS` all failed with `unknown source unit`, and the same defect affected targets such as `HOURS`. The root cause was ordering: `removeTrailingS` only strips a lowercase `s` and ran before `strings.ToLower`, so `DAYS` was lowered to `days` but never singularized to match the `unitMap` key `day`. A new `normalizeUnit()` helper lowercases first and is now used at all five call sites in `conv.go`. Brief-form case sensitivity (dates uppercase, times lowercase) is deliberately unchanged.

## Bug 2: empty target panics

`dtmate conv "90 minutes" ""` (or a whitespace-only target) crashed with `panic: index out of range [-1]` in `formatTarget`, because an empty target skipped both the single-target branch and the validation loop. `ConvertDuration` now returns a `no target units specified` error instead.

## Tests added

New `TestConvCaseInsensitiveUnits` (mixed-case and uppercase-plural source and target units), `TestConvEmptyTarget` (empty and whitespace-only targets), and `TestConvMixedSignSource` (`1 year -30 days` converts to `335 days`, locking in mid-string negative subtraction). `TestConvInvalidInput` gains four rows: `1 month` (months are deliberately unsupported), empty source, `abc days` (invalid numeric amount), and a bare `15` with no unit. Both regression tests were verified to fail against the unfixed code.

## Skipped from issue #18

Unknown-unit cases like `15 lightyears` and an `invalid_unit` target duplicate the existing fortnight tests; the zero-duration case duplicates `TestConvZeroResult`; the whitespace cases only exercise `strings.Fields` from the standard library; and `999999999 years` plus the every-unit combination produce float-precision-mangled output that would make brittle exact-match assertions.

## Verification

`go build ./...`, `go vet ./...`, and `go test ./...` all pass. End-to-end: `dtmate conv "1 Week 2 DAYS" days` now prints `9 days` (previously an error), `dtmate conv "90 minutes" ""` exits 1 with a clean error (previously a panic), and spot checks (`1h 30m` to minutes, `-d 2` decimals, mixed-sign source, brief-form `1d` still rejected while `1D` works) show no regressions.

Closes #18
