### PR TITLE
Add unix timestamp support to dur; reject ambiguous 11/12-digit timestamps

### DIFF
--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -21,7 +21,7 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.8.2"
+	ModVersion string = "1.8.3"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 
@@ -182,4 +182,25 @@ func unixStringToTime(timestamp string) (time.Time, error) {
 func isPureIntegerAtoi(s string) bool {
 	_, err := strconv.Atoi(s)
 	return err == nil
+}
+
+// isUnixTimestamp reports whether a string should be treated as a Unix
+// timestamp: a pure integer of 10 to 13 characters; 10 characters are
+// seconds and 13 are milliseconds, while ambiguous 11 and 12 character
+// values are rejected with an error by unixStringToTime instead of falling
+// through to the date/time parser; other lengths are excluded so values
+// such as "2024" or a 14-digit compact date/time like "20240101080102"
+// are still parsed as date/times
+func isUnixTimestamp(s string) bool {
+	return isPureIntegerAtoi(s) && len(s) >= 10 && len(s) <= 13
+}
+
+// parseDateTimeOrUnix parses a date/time string, treating 10-digit (seconds)
+// and 13-digit (milliseconds) integers as Unix timestamps; anything else is
+// converted from a relative date and parsed with parsetime
+func parseDateTimeOrUnix(source string) (time.Time, error) {
+	if isUnixTimestamp(source) {
+		return unixStringToTime(source)
+	}
+	return parseDateTime(ConvertRelativeDateToActual(source))
 }

--- a/README.md
+++ b/README.md
@@ -322,6 +322,14 @@ $ dtmate dur today 7h10m -u tomorrow -a
 $ dtmate dur "2024-07-01 12:00:00" 1W2D3h4m5s -a -f "%Y%m%d.%H%M%S"
 20240710.150405
 
+# unix (epoch) timestamps are accepted: 10 digits for seconds, 13 for milliseconds
+$ dtmate dur 1700265600 "1 day" -a
+2023-11-18 19:00:00 -0500 EST
+
+# combine with -f "%s" to also output unix time
+$ dtmate dur 1700265600 "1 day" -a -f "%s"
+1700352000
+
 ########################### "dtmate conv" examples ###########################
 
 # convert from one group of date/time units to another

--- a/diff.go
+++ b/diff.go
@@ -49,7 +49,7 @@ func (diff *Diff) String() string {
 // (milliseconds) integers are treated as Unix timestamps; anything else is
 // parsed with carbon first, falling back to parsetime if carbon fails
 func parseDiffTime(source string) (time.Time, error) {
-	if isPureIntegerAtoi(source) && (len(source) == 10 || len(source) == 13) {
+	if isUnixTimestamp(source) {
 		return unixStringToTime(source)
 	}
 	converted := ConvertRelativeDateToActual(source)

--- a/diff_test.go
+++ b/diff_test.go
@@ -94,6 +94,20 @@ func TestDiffUnixTimestamps(t *testing.T) {
 	testDiffStartEnd(t, "1700000000000", "1700000000500", false, "500 milliseconds")
 }
 
+func TestDiffAmbiguousTimestamp(t *testing.T) {
+	t.Parallel()
+	// 11 and 12 digit integers are neither seconds (10) nor milliseconds (13)
+	// and previously fell through to the date/time parsers
+	for _, start := range []string{"17000000001", "170000000012"} {
+		diff := NewDiff(
+			DiffWithStart(start),
+			DiffWithEnd("1700003600"))
+		if _, _, err := diff.CalculateDiff(); err == nil {
+			t.Errorf("expected an error for ambiguous timestamp %q, got nil", start)
+		}
+	}
+}
+
 func TestDiffYearOverflow(t *testing.T) {
 	t.Parallel()
 	diff := NewDiff(

--- a/dur.go
+++ b/dur.go
@@ -117,7 +117,8 @@ func (dur *Dur) Sub() ([]string, error) {
 }
 
 // addOrSub - calculates a date/time when given a starting date/time and a duration
-// also handle: the repeat and until options, relative dates, output formatting
+// also handle: the repeat and until options, relative dates, Unix timestamps,
+// output formatting
 func (dur *Dur) addOrSub(op int) ([]string, error) {
 	if dur.Repeat < 0 {
 		return nil, fmt.Errorf("repeat must not be negative: %d", dur.Repeat)
@@ -126,7 +127,7 @@ func (dur *Dur) addOrSub(op int) ([]string, error) {
 		return nil, fmt.Errorf("repeat & until are mutually exclusive")
 	}
 
-	f, err := parseDateTime(ConvertRelativeDateToActual(dur.From))
+	f, err := parseDateTimeOrUnix(dur.From)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +158,7 @@ func (dur *Dur) addOrSub(op int) ([]string, error) {
 			all = append(all, to)
 		}
 	default: // until
-		u, err := parseDateTime(ConvertRelativeDateToActual(dur.Until))
+		u, err := parseDateTimeOrUnix(dur.Until)
 		if err != nil {
 			return nil, err
 		}

--- a/dur_test.go
+++ b/dur_test.go
@@ -115,6 +115,50 @@ func testDurSubUntil(t *testing.T, from, until, periodPast string, correctSub []
 	}
 }
 
+func TestDurUnixTimestampFrom(t *testing.T) {
+	t.Parallel()
+	// a 10-digit integer from-value is a Unix timestamp in seconds; it used
+	// to be silently misparsed by parsetime as a time-of-day on the current
+	// date; "%s" output keeps the assertions timezone-independent
+	testDurAddSubOutputFormat(t, "1700265600", "1 day", "%s", "1700352000", "1700179200")
+	// a 13-digit integer is a Unix timestamp in milliseconds
+	testDurAddSubOutputFormat(t, "1700265600123", "1 day", "%s", "1700352000", "1700179200")
+}
+
+func TestDurAmbiguousTimestamp(t *testing.T) {
+	t.Parallel()
+	// 11 and 12 digit integers are neither seconds (10) nor milliseconds (13)
+	// and previously fell through to parsetime where they were misparsed
+	for _, from := range []string{"17002656001", "170026560012"} {
+		dur := NewDur(DurWithFrom(from), DurWithDur("1 day"))
+		if _, err := dur.Add(); err == nil {
+			t.Errorf("expected an error for ambiguous timestamp %q, got nil", from)
+		}
+	}
+}
+
+func TestDurUnixTimestampUntil(t *testing.T) {
+	t.Parallel()
+	dur := NewDur(
+		DurWithFrom("1700265600"),
+		DurWithDur("1 day"),
+		DurWithUntil("1700438400"),
+		DurWithOutputFormat("%s"))
+	future, err := dur.Add()
+	if err != nil {
+		t.Fatal(err)
+	}
+	correct := []string{"1700352000", "1700438400"}
+	if len(future) != len(correct) {
+		t.Fatalf("[computed: %v] != [correct: %v]", future, correct)
+	}
+	for i := range correct {
+		if future[i] != correct[i] {
+			t.Errorf("[computed: %v] != [correct: %v]", future[i], correct[i])
+		}
+	}
+}
+
 func TestDurFractionalPeriod(t *testing.T) {
 	t.Parallel()
 	from := "2024-01-01 00:00:00"


### PR DESCRIPTION
## Summary

While reviewing unix time support across the sub-commands, `dur` turned out to silently misparse unix-timestamp input: `dtmate dur 1700265600 "1 day" -a` returned a result based on the current date/time instead of 2023-11-18, because parsetime read the 10-digit integer as a time-of-day (17:00:26) on today's date. `fmt` and `diff` already intercept unix timestamps before general date parsing; `dur` never did. This PR closes that gap and also tightens handling of ambiguous timestamp lengths in both `dur` and `diff`.

## Fix

A new shared helper `parseDateTimeOrUnix` in `DateTimeMate.go` treats a pure integer of 10 digits as unix seconds and 13 digits as unix milliseconds, delegating everything else to the existing relative-date and parsetime path. `dur` now routes both its from-value and its `--until` value (which had the same latent bug) through this helper. The length check lives in a new `isUnixTimestamp` predicate, and `diff`'s `parseDiffTime` was refactored to use it, so all sub-commands now share one definition of what counts as a unix timestamp.

## Ambiguous lengths rejected

Pure integers of 11 or 12 digits are neither seconds nor milliseconds and previously fell through to the date/time parsers, where they were silently misparsed. They are now rejected in both `dur` and `diff` with the existing `ambiguous timestamp length` error from `unixStringToTime`, matching the behavior `fmt` already had. Shorter values such as `2024` and 14-digit compact date/times such as `20240101080102` are unaffected and still parse as date/times.

## Tests

New `TestDurUnixTimestampFrom` (10-digit and 13-digit input, add and sub, asserted via `-f "%s"` output so the expectations are timezone-independent), `TestDurUnixTimestampUntil` (unix timestamp as the `--until` boundary), `TestDurAmbiguousTimestamp`, and `TestDiffAmbiguousTimestamp`. The dur tests were verified to fail against the unfixed code, reproducing the original now-based misparse.

## Documentation

The README `dur` examples section gains two unix-timestamp examples (input in seconds, and round-tripping back to unix time with `-f "%s"`), which also become available through the CLI's `-e` flag. Version bumped to 1.8.3.

## Verification

`go build ./...`, `go vet ./...`, and `go test ./...` all pass. End-to-end: `dur 1700265600 "1 day" -a` now returns `2023-11-18 19:00:00 -0500 EST`, `-f "%s"` round-trips to `1700352000`, 13-digit millisecond input and unix `--until` values work, 11/12-digit inputs error cleanly in both `dur` and `diff`, and date strings, bare times, 14-digit compact date/times, and relative dates are unchanged.
