### PR TITLE
Add durmath sub-command for duration arithmetic

### DIFF
--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -21,7 +21,7 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.8.3"
+	ModVersion string = "1.9.0"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,16 @@ The command-line program, `dtmate` *(along with the golang package)* allows you 
 </details>
 
 <details>
-<summary>5. Reformat a date/time</summary>
+<summary>5. Add or subtract two durations, even when expressed in different units?</summary>
+
+* add: `dtmate durmath "1 hour 30 minutes" "45 minutes" -a`
+* * `2 hours 15 minutes`
+* subtract, with a signed result when the second duration is larger: `dtmate durmath "45 minutes" "1 hour" -s`
+* * `-15 minutes`
+</details>
+
+<details>
+<summary>6. Reformat a date/time</summary>
 
 * convert the output of the `date` utility: `dtmate fmt "$(date)" "%F %T"`
 * * where `($date)` equals `Mon Jul 22 22:49:18 EDT 2024`
@@ -123,6 +132,24 @@ fmt.Println("new format:", newFormat) // 2024-07-22 08:40:33
 ```
 </details>
 
+<details>
+<summary>Example 5 - duration arithmetic</summary>
+
+```go
+first := "1 hour 30 minutes"
+second := "45 minutes"
+dm := DateTimeMate.NewDurMath(
+	DateTimeMate.DurMathWithFirst(first),
+	DateTimeMate.DurMathWithSecond(second))
+sum, err := dm.Add()
+if err != nil { ... }
+fmt.Println(sum) // 2 hours 15 minutes
+difference, err := dm.Sub()
+if err != nil { ... }
+fmt.Println(difference) // 45 minutes
+```
+</details>
+
 
 See also the [example](cmd/example/main.go) program.
 
@@ -143,6 +170,7 @@ Available Commands:
   conv        Convert a duration from group of units to another
   diff        Output the difference between two date/times
   dur         Output a date/time when given a starting date/time and duration
+  durmath     Add or subtract two durations
   fmt         reformat a date/time
   help        Help about any command
 
@@ -329,6 +357,40 @@ $ dtmate dur 1700265600 "1 day" -a
 # combine with -f "%s" to also output unix time
 $ dtmate dur 1700265600 "1 day" -a -f "%s"
 1700352000
+
+########################### "dtmate durmath" examples ###########################
+
+# add two durations expressed in different units
+$ dtmate durmath "1 hour 30 minutes" "45 minutes" -a
+2 hours 15 minutes
+
+# subtract the second duration from the first
+$ dtmate durmath "1 hour 30 minutes" "45 minutes" -s
+45 minutes
+
+# brief input and output
+$ dtmate durmath 1h30m 45m -a -b
+2h15m
+
+# results are signed when the second duration is larger
+$ dtmate durmath "45 minutes" "1 hour" -s
+-15 minutes
+
+# mixed units between the two durations
+$ dtmate durmath "1 week" "3 days 12 hours" -s
+3 days 12 hours
+
+# convert the result to specific target units
+$ dtmate durmath "1 day" "90 minutes" -s -c minutes
+1350 minutes
+
+# show the smallest unit with decimal places, rounded
+$ dtmate durmath "1 hour" "30 minutes" -s -c hours -d 1
+0.5 hours
+
+# sub-second units appear only when the result needs them
+$ dtmate durmath "1.5 seconds" "250 milliseconds" -s
+1 second 250 milliseconds
 
 ########################### "dtmate conv" examples ###########################
 

--- a/cmd/dtmate/cmd/dur.go
+++ b/cmd/dtmate/cmd/dur.go
@@ -40,22 +40,25 @@ func init() {
 	durCmd.MarkFlagsOneRequired("add", "sub")
 	durCmd.MarkFlagsMutuallyExclusive("add", "sub")
 	durCmd.MarkFlagsMutuallyExclusive("repeat", "until")
-	durCmd.SetFlagErrorFunc(negativeDurationHint)
+	durCmd.SetFlagErrorFunc(negativeDurationHint("dur", "Use -s/--sub to subtract, e.g.:\n  dtmate dur now 1h -s"))
 }
 
-// negativeDurationHint rewrites the cryptic pflag error produced when a user
-// passes a negative-looking duration (e.g. "-1h") to 'dur' into a clear message
-// directing them to -s/--sub. Any other flag error is returned unchanged.
-func negativeDurationHint(cmd *cobra.Command, err error) error {
-	const marker = "unknown shorthand flag: '"
-	msg := err.Error()
-	if i := strings.Index(msg, marker); i != -1 {
-		c := msg[i+len(marker)]
-		if c >= '0' && c <= '9' {
-			return fmt.Errorf("'dur' does not accept negative durations.\nUse -s/--sub to subtract, e.g.:\n  dtmate dur now 1h -s\n")
+// negativeDurationHint returns a cobra flag-error function for the given verb
+// that rewrites the cryptic pflag error produced when a user passes a
+// negative-looking duration (e.g. "-1h") into a clear message containing the
+// given hint. Any other flag error is returned unchanged.
+func negativeDurationHint(verb, hint string) func(*cobra.Command, error) error {
+	return func(cmd *cobra.Command, err error) error {
+		const marker = "unknown shorthand flag: '"
+		msg := err.Error()
+		if i := strings.Index(msg, marker); i != -1 {
+			c := msg[i+len(marker)]
+			if c >= '0' && c <= '9' {
+				return fmt.Errorf("'%s' does not accept negative durations.\n%s\n", verb, hint)
+			}
 		}
+		return err
 	}
-	return err
 }
 
 func outputDur(from, duration, until, format string, repeat int) {

--- a/cmd/dtmate/cmd/dur_test.go
+++ b/cmd/dtmate/cmd/dur_test.go
@@ -1,8 +1,8 @@
 // dur_test.go verifies the CLI-layer helpers for the 'dur' sub-command.
-// It covers negativeDurationHint, which turns the cryptic pflag "unknown
-// shorthand flag" error (produced when a user passes a negative-looking
-// duration such as -1h) into a clear message directing them to -s/--sub, while
-// leaving every other flag error untouched.
+// It covers the negativeDurationHint factory as registered for 'dur', which
+// turns the cryptic pflag "unknown shorthand flag" error (produced when a user
+// passes a negative-looking duration such as -1h) into a clear message
+// directing them to -s/--sub, while leaving every other flag error untouched.
 package cmd
 
 import (
@@ -25,9 +25,10 @@ func TestNegativeDurationHint(t *testing.T) {
 		{name: "unrelated error", err: errors.New("some other error"), rewrite: false},
 	}
 
+	hint := negativeDurationHint("dur", "Use -s/--sub to subtract, e.g.:\n  dtmate dur now 1h -s")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := negativeDurationHint(nil, tt.err)
+			got := hint(nil, tt.err)
 			if !tt.rewrite {
 				if got != tt.err {
 					t.Fatalf("expected error to pass through unchanged, got: %v", got)

--- a/cmd/dtmate/cmd/durmath.go
+++ b/cmd/dtmate/cmd/durmath.go
@@ -1,0 +1,87 @@
+// durmath.go implements the 'durmath' sub-command, which adds or subtracts
+// two durations that may be expressed in different units. The operation is
+// selected with -a/--add or -s/--sub, and the signed result can optionally be
+// converted to target units (-c), rounded (-d), or output in brief form (-b).
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/jftuga/DateTimeMate"
+	"github.com/spf13/cobra"
+)
+
+// durMathCmd represents the durmath command
+var durMathCmd = &cobra.Command{
+	Use:   "durmath [duration1] [duration2]",
+	Short: "Add or subtract two durations",
+	Example: `  dtmate durmath "1 hour 30 minutes" "45 minutes" -a
+  dtmate durmath 1h30m 45m -a -b
+  dtmate durmath "1 day" "90 minutes" -s -c minutes`,
+	Args: cobra.MatchAll(cobra.ExactArgs(2)),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return outputDurMath(args[0], args[1])
+	},
+}
+
+var (
+	optDurMathAdd      bool
+	optDurMathSub      bool
+	optDurMathConv     string
+	optDurMathBrief    bool
+	optDurMathDecimals int
+)
+
+func init() {
+	rootCmd.AddCommand(durMathCmd)
+	durMathCmd.Flags().BoolVarP(&optDurMathAdd, "add", "a", false, "add the two durations")
+	durMathCmd.Flags().BoolVarP(&optDurMathSub, "sub", "s", false, "subtract the second duration from the first")
+	durMathCmd.Flags().StringVarP(&optDurMathConv, "conv", "c", "", "convert resulting duration to another group of units")
+	durMathCmd.Flags().BoolVarP(&optDurMathBrief, "brief", "b", false, "output in brief format, such as: 1Y3W4D5h6m7s")
+	durMathCmd.Flags().IntVarP(&optDurMathDecimals, "decimals", "d", 0, "with -c: show the smallest unit with this many decimal places, rounded")
+	durMathCmd.MarkFlagsOneRequired("add", "sub")
+	durMathCmd.MarkFlagsMutuallyExclusive("add", "sub")
+	durMathCmd.SetFlagErrorFunc(negativeDurationHint("durmath", "Use -a/--add or -s/--sub to control the operation, e.g.:\n  dtmate durmath 2h 30m -s"))
+}
+
+// outputDurMath runs the requested duration arithmetic and prints the result;
+// a negative-duration error is returned to cobra so the usage text is shown,
+// consistent with the flag-parse path that catches leading-dash negatives
+func outputDurMath(first, second string) error {
+	if optDurMathDecimals != 0 && optDurMathConv == "" {
+		fmt.Fprintln(os.Stderr, "-d/--decimals requires -c/--conv")
+		os.Exit(1)
+	}
+	dm := DateTimeMate.NewDurMath(
+		DateTimeMate.DurMathWithFirst(first),
+		DateTimeMate.DurMathWithSecond(second),
+		DateTimeMate.DurMathWithTarget(optDurMathConv),
+		DateTimeMate.DurMathWithBrief(optDurMathBrief),
+		DateTimeMate.DurMathWithDecimals(optDurMathDecimals))
+
+	var result string
+	var err error
+	if optDurMathAdd {
+		result, err = dm.Add()
+	} else {
+		result, err = dm.Sub()
+	}
+	if err != nil {
+		if errors.Is(err, DateTimeMate.ErrNegativeDuration) {
+			// the trailing newline separates the error from cobra's usage
+			// block, matching the negativeDurationHint output
+			return fmt.Errorf("%w\n", err)
+		}
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if optRootNoNewline {
+		fmt.Print(result)
+	} else {
+		fmt.Println(result)
+	}
+	return nil
+}

--- a/cmd/dtmate/cmd/durmath_test.go
+++ b/cmd/dtmate/cmd/durmath_test.go
@@ -1,0 +1,45 @@
+// durmath_test.go verifies the CLI-layer helpers for the 'durmath'
+// sub-command. It covers the negativeDurationHint factory as registered for
+// 'durmath', ensuring pflag digit-shorthand errors (produced when a user
+// passes a negative-looking duration such as -30m) are rewritten with the
+// durmath wording, while every other flag error passes through untouched.
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestDurMathNegativeDurationHint(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		rewrite  bool   // true when the error should be replaced with the hint
+		contains string // substring the returned error must contain
+	}{
+		{name: "brief negative duration", err: errors.New("unknown shorthand flag: '3' in -30m"), rewrite: true, contains: "-a/--add or -s/--sub"},
+		{name: "fractional negative duration", err: errors.New("unknown shorthand flag: '1' in -1.5h"), rewrite: true, contains: "'durmath'"},
+		{name: "unknown letter flag", err: errors.New("unknown shorthand flag: 'x' in -x"), rewrite: false},
+		{name: "unrelated error", err: errors.New("some other error"), rewrite: false},
+	}
+
+	hint := negativeDurationHint("durmath", "Use -a/--add or -s/--sub to control the operation, e.g.:\n  dtmate durmath 2h 30m -s")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hint(nil, tt.err)
+			if !tt.rewrite {
+				if got != tt.err {
+					t.Fatalf("expected error to pass through unchanged, got: %v", got)
+				}
+				return
+			}
+			if got == tt.err {
+				t.Fatal("expected error to be rewritten, got the original")
+			}
+			if !strings.Contains(got.Error(), tt.contains) {
+				t.Errorf("rewritten error %q does not contain %q", got.Error(), tt.contains)
+			}
+		})
+	}
+}

--- a/conv.go
+++ b/conv.go
@@ -95,21 +95,27 @@ func normalizeUnit(unit string) string {
 	return removeTrailingS(strings.ToLower(unit))
 }
 
-// parseSource parses the Source field of the Conv struct
-// and converts it to a total number of seconds.
+// parseDurationSeconds converts a duration string to a total number of seconds.
 //
-// The function expects the Source string to contain alternating numeric values and time unit strings
-// (e.g., "1 hour 30 minutes"). It supports various time units (defined in unitMap) in both singular
-// and plural forms.
-//
-// The function iterates through the Source string, parsing each numeric value and its corresponding
-// time unit. It then converts each time value to seconds and accumulates the total.
+// The source may be in long form ("1 hour 30 minutes") or brief form ("1h30m");
+// brief input is first expanded to long form. Long form must contain alternating
+// numeric values and time unit strings, with units (defined in unitMap) accepted
+// in both singular and plural forms.
 //
 // Returns:
 //   - float64: The total time converted to seconds.
-//   - error: An error if parsing fails, typically due to invalid numeric input.
-func (conv *Conv) parseSource() (float64, error) {
-	parts := strings.Fields(conv.Source)
+//   - error: An error if parsing fails, typically due to invalid numeric input
+//     or an unknown unit.
+func parseDurationSeconds(source string) (float64, error) {
+	if !isLongFormDuration(strings.Fields(source)) {
+		// brief format is being used so convert to long duration format
+		expandedSource, err := expandBriefSourceDuration(source)
+		if nil != err {
+			return 0, fmt.Errorf("invalid source duration %q: %v", source, err)
+		}
+		source = expandedSource
+	}
+	parts := strings.Fields(source)
 	var totalSeconds float64
 
 	for i := 0; i < len(parts); i += 2 {
@@ -118,7 +124,7 @@ func (conv *Conv) parseSource() (float64, error) {
 			return 0, err
 		}
 		if i+1 >= len(parts) {
-			return 0, fmt.Errorf("missing unit after %q in: %s", parts[i], conv.Source)
+			return 0, fmt.Errorf("missing unit after %q in: %s", parts[i], source)
 		}
 		unit := normalizeUnit(parts[i+1])
 		seconds, ok := unitMap[unit]
@@ -128,6 +134,34 @@ func (conv *Conv) parseSource() (float64, error) {
 		totalSeconds += value * seconds
 	}
 	return totalSeconds, nil
+}
+
+// resolveTargetUnits validates a target unit specification and expands it into
+// a list of long-form unit names. The target may be space-separated long-form
+// units ("hours minutes"), a single long-form unit, or a brief specification
+// ("hm" or "hms.msusns"). An empty or whitespace-only target and any unknown
+// unit produce an error.
+func resolveTargetUnits(target string) ([]string, error) {
+	targetUnits := strings.Fields(target)
+	if len(targetUnits) == 0 {
+		return nil, fmt.Errorf("no target units specified")
+	}
+	if len(targetUnits) == 1 {
+		if _, ok := unitMap[normalizeUnit(target)]; !ok {
+			// brief format is being used so convert to long duration format
+			var err error
+			targetUnits, err = expandBriefTargetDuration(target)
+			if nil != err {
+				return nil, err
+			}
+		}
+	}
+	for _, unit := range targetUnits {
+		if _, ok := unitMap[normalizeUnit(unit)]; !ok {
+			return nil, fmt.Errorf("unknown target unit: %q", unit)
+		}
+	}
+	return targetUnits, nil
 }
 
 // formatTarget converts a duration in seconds to a human-readable
@@ -272,7 +306,6 @@ func expandBriefTargetDuration(period string) ([]string, error) {
 //   - string: The converted duration in the specified target format.
 //   - error: An error if any step of the conversion process fails.
 func (conv *Conv) ConvertDuration() (string, error) {
-	var err error
 	if conv.Decimals < 0 || conv.Decimals > 9 {
 		return "", fmt.Errorf("decimals must be between 0 and 9: %d", conv.Decimals)
 	}
@@ -281,36 +314,13 @@ func (conv *Conv) ConvertDuration() (string, error) {
 		conv.Source = s
 		isNegativeDuration = true
 	}
-	if !isLongFormDuration(strings.Fields(conv.Source)) {
-		// brief format is being used so convert to long duration format
-		expandedSource, err := expandBriefSourceDuration(conv.Source)
-		if nil != err {
-			return "", fmt.Errorf("invalid source duration %q: %v", conv.Source, err)
-		}
-		conv.Source = expandedSource
-	}
-	seconds, err := conv.parseSource()
+	seconds, err := parseDurationSeconds(conv.Source)
 	if err != nil {
 		return "", err
 	}
-	targetUnits := strings.Fields(conv.Target)
-	if len(targetUnits) == 0 {
-		return "", fmt.Errorf("no target units specified")
-	}
-	if len(targetUnits) == 1 {
-		_, ok := unitMap[normalizeUnit(conv.Target)]
-		if !ok {
-			// brief format is being used so convert to long duration format
-			targetUnits, err = expandBriefTargetDuration(conv.Target)
-			if nil != err {
-				return "", err
-			}
-		}
-	}
-	for _, unit := range targetUnits {
-		if _, ok := unitMap[normalizeUnit(unit)]; !ok {
-			return "", fmt.Errorf("unknown target unit: %q", unit)
-		}
+	targetUnits, err := resolveTargetUnits(conv.Target)
+	if err != nil {
+		return "", err
 	}
 	result := conv.formatTarget(seconds, targetUnits)
 	if conv.Brief {

--- a/durmath.go
+++ b/durmath.go
@@ -1,0 +1,178 @@
+// durmath.go implements duration arithmetic: adding or subtracting two
+// durations that may be expressed in different units. Results are signed and
+// rendered either as a largest-to-smallest breakdown from years down to
+// seconds (extended with sub-second units only when the result carries a
+// sub-second remainder) or converted to caller-specified target units.
+
+package DateTimeMate
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+)
+
+// ErrNegativeDuration is returned when either duration operand contains a
+// negative amount; the sign of the operation is already carried by Add/Sub,
+// so negative inputs are rejected.
+var ErrNegativeDuration = errors.New("durmath does not accept negative durations; use -a/--add or -s/--sub to control the operation")
+
+// DurMath adds or subtracts two durations, First and Second, which may be
+// expressed in different units. Target optionally converts the result to a
+// specific group of units; when empty, the result is a full breakdown from
+// years down to seconds. Brief renders compact output such as "2h15m".
+// Decimals sets the number of decimal places on the smallest output unit.
+type DurMath struct {
+	First    string
+	Second   string
+	Target   string
+	Brief    bool
+	Decimals int
+}
+
+// OptionsDurMath is a functional option used to configure a DurMath.
+type OptionsDurMath func(*DurMath)
+
+// NewDurMath returns a DurMath configured with the given options.
+func NewDurMath(options ...OptionsDurMath) *DurMath {
+	dm := &DurMath{}
+	for _, opt := range options {
+		opt(dm)
+	}
+	return dm
+}
+
+// DurMathWithFirst sets the first duration operand.
+func DurMathWithFirst(first string) OptionsDurMath {
+	return func(dm *DurMath) {
+		dm.First = first
+	}
+}
+
+// DurMathWithSecond sets the second duration operand.
+func DurMathWithSecond(second string) OptionsDurMath {
+	return func(dm *DurMath) {
+		dm.Second = second
+	}
+}
+
+// DurMathWithTarget sets the target units for the result; an empty target
+// selects the default full-breakdown output.
+func DurMathWithTarget(target string) OptionsDurMath {
+	return func(dm *DurMath) {
+		dm.Target = target
+	}
+}
+
+// DurMathWithBrief enables brief output, such as: 2h15m
+func DurMathWithBrief(brief bool) OptionsDurMath {
+	return func(dm *DurMath) {
+		dm.Brief = brief
+	}
+}
+
+// DurMathWithDecimals sets the number of decimal places used when formatting
+// the last (smallest) output unit; 0 keeps the default integer truncation
+func DurMathWithDecimals(decimals int) OptionsDurMath {
+	return func(dm *DurMath) {
+		dm.Decimals = decimals
+	}
+}
+
+// String returns a human-readable summary of the DurMath configuration.
+func (dm *DurMath) String() string {
+	return fmt.Sprintf("First:%v Second:%v Target:%v Brief:%v Decimals:%v", dm.First, dm.Second, dm.Target, dm.Brief, dm.Decimals)
+}
+
+// Add returns the sum of the two durations.
+func (dm *DurMath) Add() (string, error) {
+	return dm.compute(false)
+}
+
+// Sub returns the signed difference of the two durations, First minus Second;
+// a negative result is rendered with a single leading "-".
+func (dm *DurMath) Sub() (string, error) {
+	return dm.compute(true)
+}
+
+// default output unit breakdowns: years down to seconds, extended through
+// nanoseconds only when the result has a non-zero sub-second remainder
+var (
+	durMathDefaultUnits = []string{"years", "weeks", "days", "hours", "minutes", "seconds"}
+	durMathAllUnits     = []string{"years", "weeks", "days", "hours", "minutes", "seconds", "milliseconds", "microseconds", "nanoseconds"}
+)
+
+// checkNegativeDuration rejects an operand containing "-" with
+// ErrNegativeDuration. A legal duration never contains "-" (units are letters,
+// amounts are digits and dots), so a whole-string check also catches
+// mid-string negative amounts such as "1 year -30 days" that the parse
+// machinery would otherwise accept.
+func checkNegativeDuration(source string) error {
+	if strings.Contains(source, "-") {
+		return ErrNegativeDuration
+	}
+	return nil
+}
+
+// compute parses both operands, adds or subtracts them, and formats the
+// signed result; the absolute value is formatted and a leading "-" is
+// prepended when the result is negative
+func (dm *DurMath) compute(subtract bool) (string, error) {
+	if dm.Decimals < 0 || dm.Decimals > 9 {
+		return "", fmt.Errorf("decimals must be between 0 and 9: %d", dm.Decimals)
+	}
+	if err := checkNegativeDuration(dm.First); err != nil {
+		return "", err
+	}
+	if err := checkNegativeDuration(dm.Second); err != nil {
+		return "", err
+	}
+	first, err := parseDurationSeconds(dm.First)
+	if err != nil {
+		return "", fmt.Errorf("first duration: %w", err)
+	}
+	second, err := parseDurationSeconds(dm.Second)
+	if err != nil {
+		return "", fmt.Errorf("second duration: %w", err)
+	}
+
+	result := first + second
+	if subtract {
+		result = first - second
+	}
+	abs := math.Abs(result)
+	if math.Round(abs*1e9) == 0 {
+		// snap float noise below half a nanosecond to exactly zero so a
+		// zero result renders as "0 seconds", never "-0 seconds"
+		result, abs = 0, 0
+	}
+	negative := result < 0
+
+	units := durMathDefaultUnits
+	if dm.Target != "" {
+		units, err = resolveTargetUnits(dm.Target)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		// extend with sub-second units only when a sub-second remainder
+		// survives rounding to whole nanoseconds, so binary float residue
+		// does not trigger a bogus extension
+		frac := abs - math.Floor(abs)
+		if r := math.Round(frac * 1e9); r >= 1 && r < 1e9 {
+			units = durMathAllUnits
+		}
+	}
+
+	formatter := &Conv{Decimals: dm.Decimals}
+	out := formatter.formatTarget(abs, units)
+	if dm.Brief {
+		out = shrinkPeriod(out)
+	}
+	out = strings.TrimSpace(out)
+	if negative {
+		out = "-" + out
+	}
+	return out, nil
+}

--- a/durmath_test.go
+++ b/durmath_test.go
@@ -1,0 +1,165 @@
+// durmath_test.go verifies the DurMath duration arithmetic API: adding and
+// subtracting durations across mixed units, signed results, target-unit
+// conversion, decimals, brief output, and rejection of invalid or negative
+// inputs.
+package DateTimeMate
+
+import (
+	"errors"
+	"testing"
+)
+
+func testDurMath(t *testing.T, first, second string, brief bool, correctAdd, correctSub string) {
+	t.Helper()
+	dm := NewDurMath(
+		DurMathWithFirst(first),
+		DurMathWithSecond(second),
+		DurMathWithBrief(brief))
+
+	result, err := dm.Add()
+	if err != nil {
+		t.Error(err)
+	}
+	if result != correctAdd {
+		t.Errorf("\n[computed: %v] !=\n[correct : %v]", result, correctAdd)
+	}
+
+	result, err = dm.Sub()
+	if err != nil {
+		t.Error(err)
+	}
+	if result != correctSub {
+		t.Errorf("\n[computed: %v] !=\n[correct : %v]", result, correctSub)
+	}
+}
+
+func testDurMathConv(t *testing.T, first, second, target string, brief bool, decimals int, correctAdd, correctSub string) {
+	t.Helper()
+	dm := NewDurMath(
+		DurMathWithFirst(first),
+		DurMathWithSecond(second),
+		DurMathWithTarget(target),
+		DurMathWithBrief(brief),
+		DurMathWithDecimals(decimals))
+
+	result, err := dm.Add()
+	if err != nil {
+		t.Error(err)
+	}
+	if result != correctAdd {
+		t.Errorf("\n[computed: %v] !=\n[correct : %v]", result, correctAdd)
+	}
+
+	result, err = dm.Sub()
+	if err != nil {
+		t.Error(err)
+	}
+	if result != correctSub {
+		t.Errorf("\n[computed: %v] !=\n[correct : %v]", result, correctSub)
+	}
+}
+
+func TestDurMathHoursMinutes(t *testing.T) {
+	t.Parallel()
+	testDurMath(t, "1 hour 30 minutes", "45 minutes", false, "2 hours 15 minutes", "45 minutes")
+	testDurMath(t, "1h30m", "45m", false, "2 hours 15 minutes", "45 minutes")
+	testDurMath(t, "1h30m", "45m", true, "2h15m", "45m")
+}
+
+func TestDurMathSignedResult(t *testing.T) {
+	t.Parallel()
+	// subtraction is signed when the second duration is larger
+	testDurMath(t, "45 minutes", "1 hour", false, "1 hour 45 minutes", "-15 minutes")
+	testDurMath(t, "45 minutes", "1 hour", true, "1h45m", "-15m")
+}
+
+func TestDurMathMixedUnits(t *testing.T) {
+	t.Parallel()
+	testDurMath(t, "1 week", "3 days 12 hours", false, "1 week 3 days 12 hours", "3 days 12 hours")
+	testDurMath(t, "1 day", "90 minutes", false, "1 day 1 hour 30 minutes", "22 hours 30 minutes")
+}
+
+func TestDurMathCaseInsensitiveUnits(t *testing.T) {
+	t.Parallel()
+	// long-form units are case-insensitive, singular or plural
+	testDurMath(t, "1 HOUR 30 Minutes", "45 MINUTES", false, "2 hours 15 minutes", "45 minutes")
+}
+
+func TestDurMathTargetUnits(t *testing.T) {
+	t.Parallel()
+	testDurMathConv(t, "1 day", "90 minutes", "minutes", false, 0, "1530 minutes", "1350 minutes")
+	// brief target specification
+	testDurMathConv(t, "1 day", "90 minutes", "hm", false, 0, "25 hours 30 minutes", "22 hours 30 minutes")
+	testDurMathConv(t, "1 day", "90 minutes", "hm", true, 0, "25h30m", "22h30m")
+}
+
+func TestDurMathDecimals(t *testing.T) {
+	t.Parallel()
+	testDurMathConv(t, "1 hour", "30 minutes", "hours", false, 1, "1.5 hours", "0.5 hours")
+	testDurMathConv(t, "1 hour", "30 minutes", "hours", false, 2, "1.50 hours", "0.50 hours")
+}
+
+func TestDurMathSubSecond(t *testing.T) {
+	t.Parallel()
+	// sub-second units appear only when the result has a sub-second remainder
+	testDurMath(t, "1.5 seconds", "250 milliseconds", false, "1 second 750 milliseconds", "1 second 250 milliseconds")
+	testDurMath(t, "1 second", "500 milliseconds", false, "1 second 500 milliseconds", "500 milliseconds")
+	// whole-second results stay at second granularity
+	testDurMath(t, "750 milliseconds", "250 milliseconds", false, "1 second", "500 milliseconds")
+}
+
+func TestDurMathZeroResult(t *testing.T) {
+	t.Parallel()
+	// a zero result renders as seconds, not nanoseconds
+	testDurMath(t, "1 hour", "60 minutes", false, "2 hours", "0 seconds")
+	testDurMath(t, "1 hour", "60 minutes", true, "2h", "0s")
+}
+
+func TestDurMathInvalidInput(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, first, second, target string
+		decimals                    int
+		negative                    bool // true when ErrNegativeDuration is expected
+	}{
+		{name: "unknown unit in first", first: "1 fortnight", second: "1 hour"},
+		{name: "unknown unit in second", first: "1 hour", second: "1 fortnight"},
+		{name: "unknown target unit", first: "1 hour", second: "1 hour", target: "bananas"},
+		{name: "empty first", first: "", second: "1 hour"},
+		{name: "empty second", first: "1 hour", second: ""},
+		{name: "whitespace-only target", first: "1 hour", second: "1 hour", target: "   "},
+		{name: "month in first", first: "1 month", second: "1 hour"},
+		{name: "month in second", first: "1 hour", second: "1 month"},
+		{name: "decimals below range", first: "1 hour", second: "1 hour", target: "hours", decimals: -1},
+		{name: "decimals above range", first: "1 hour", second: "1 hour", target: "hours", decimals: 10},
+		{name: "missing unit in first", first: "1 hour 2", second: "1 hour"},
+		{name: "missing unit in second", first: "1 hour", second: "1 hour 2"},
+		{name: "leading negative long first", first: "-1 hour", second: "1 hour", negative: true},
+		{name: "leading negative long second", first: "1 hour", second: "-1 hour", negative: true},
+		{name: "leading negative brief first", first: "-1h30m", second: "1 hour", negative: true},
+		{name: "leading negative brief second", first: "1 hour", second: "-1h30m", negative: true},
+		{name: "mid-string negative long first", first: "1 year -30 days", second: "1 hour", negative: true},
+		{name: "mid-string negative long second", first: "1 hour", second: "1 year -30 days", negative: true},
+		{name: "mid-string negative brief first", first: "1Y-30D", second: "1 hour", negative: true},
+		{name: "mid-string negative brief second", first: "1 hour", second: "1Y-30D", negative: true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dm := NewDurMath(
+				DurMathWithFirst(c.first),
+				DurMathWithSecond(c.second),
+				DurMathWithTarget(c.target),
+				DurMathWithDecimals(c.decimals))
+			if _, err := dm.Add(); err == nil {
+				t.Errorf("Add: expected an error for first %q second %q target %q decimals %d, got nil", c.first, c.second, c.target, c.decimals)
+			} else if c.negative && !errors.Is(err, ErrNegativeDuration) {
+				t.Errorf("Add: expected ErrNegativeDuration, got: %v", err)
+			}
+			if _, err := dm.Sub(); err == nil {
+				t.Errorf("Sub: expected an error for first %q second %q target %q decimals %d, got nil", c.first, c.second, c.target, c.decimals)
+			} else if c.negative && !errors.Is(err, ErrNegativeDuration) {
+				t.Errorf("Sub: expected ErrNegativeDuration, got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds a new `durmath` verb that adds or subtracts two durations, where the two durations may be expressed in different units, e.g. `dtmate durmath "1 hour 30 minutes" "45 minutes" -a` yields `2 hours 15 minutes`. The "difference between two durations" use case is covered by signed subtraction: `dtmate durmath "45 minutes" "1 hour" -s` yields `-15 minutes`. The operation is selected with `-a/--add` or `-s/--sub` (exactly one required, enforced by cobra flag groups), mirroring the `dur` sub-command.

## Output behavior

Default output is a diff-style normalized breakdown from years down to seconds that omits zero units. Sub-second units (milliseconds, microseconds, nanoseconds) are included only when the result carries a non-zero sub-second remainder, so nothing is silently truncated: `dtmate durmath "1.5 seconds" "250 milliseconds" -s` yields `1 second 250 milliseconds`. A zero result renders as `0 seconds`. The result can be converted to specific target units with `-c/--conv` (long or brief form, same semantics as `diff`), rounded with `-d/--decimals` (0-9, requires `-c`), and compacted with `-b/--brief` (`2h15m`).

## Negative durations

Negative duration inputs are rejected, consistent with the decision made for `dur` in #37: the sign of the operation is already carried by `-a`/`-s`, so a negative input is a double-negative footgun. The guard is a whole-string check in the library performed before parsing, because the conv parse machinery would otherwise accept both leading and mid-string negative amounts (`"-30 days 1 year"`, `"1 year -30 days"`, `"1Y-30D"`). The guard returns a new sentinel error, `ErrNegativeDuration`, which the CLI hands back to cobra so the message is printed with the usage text, matching the pflag path: arguments that begin with `-` (such as `-30m`) never reach the library and are instead caught by a generalized `negativeDurationHint` flag-error function, now parameterized by verb and registered on both `dur` and `durmath`. Subtraction output remains signed; the asymmetry (signed out, unsigned in) is deliberate.

## Library API

New file `durmath.go` follows the established functional-options pattern: `NewDurMath` with `DurMathWithFirst`, `DurMathWithSecond`, `DurMathWithTarget`, `DurMathWithBrief`, and `DurMathWithDecimals`, plus `(*DurMath).Add()` and `(*DurMath).Sub()` returning `(string, error)`. The heavy lifting reuses the conv machinery through a small behavior-preserving refactor of `conv.go`: the source parse path was extracted into `parseDurationSeconds()` and the target validation/expansion into `resolveTargetUnits()`, both now shared by `ConvertDuration` and `DurMath` with identical error messages.

## Testing

Library tests in `durmath_test.go` cover every example above plus mixed-unit operands, brief targets, decimals, case-insensitive long-form input, and a 20-case error table (unknown units, empty operands, whitespace-only target, `"1 month"`, decimals out of range, dangling amounts, and negative inputs in every shape applied to both operands, asserting `ErrNegativeDuration` identity). CLI tests cover the generalized hint function for both verbs. Verified with `go build ./...`, `go vet ./...`, `go test ./...`, and every example run end-to-end against the built binary, plus a regression sweep of `conv`, `dur`, `diff`, and `fmt`.

## Other changes

`ModVersion` bumped to 1.9.0. README updated with the new verb in the intro inquiry list and Available Commands block, a `durmath` block in the embedded Command Line Examples (feeds `dtmate -e`), and a library usage example.
