### PR TITLE
Add -A/--absolute flag to diff and durmath

### DIFF
--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -21,7 +21,7 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.9.0"
+	ModVersion string = "1.10.0"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The command-line program, `dtmate` *(along with the golang package)* allows you 
 * * `2 hours 15 minutes`
 * subtract, with a signed result when the second duration is larger: `dtmate durmath "45 minutes" "1 hour" -s`
 * * `-15 minutes`
+* same input, always absolute with the `-A` option: `dtmate durmath "45 minutes" "1 hour" -s -A`
+* * `15 minutes`
 </details>
 
 <details>
@@ -290,6 +292,14 @@ $ dtmate diff "$(date)" 2020
 $ dtmate diff "$(date)" 2020 -b
 -4Y24W1D7h21m53s
 
+# ending time first yields a signed result
+$ dtmate diff 15:30:45 12:00:00
+-3 hours 30 minutes 45 seconds
+
+# same input, always output an absolute (positive) duration
+$ dtmate diff 15:30:45 12:00:00 -A
+3 hours 30 minutes 45 seconds
+
 # using microsecond formatting
 $ dtmate diff 2024-06-07T08:00:00Z 2024-06-07T08:00:00.000123Z
 123 microseconds
@@ -375,6 +385,10 @@ $ dtmate durmath 1h30m 45m -a -b
 # results are signed when the second duration is larger
 $ dtmate durmath "45 minutes" "1 hour" -s
 -15 minutes
+
+# same input, always output an absolute (positive) duration
+$ dtmate durmath "45 minutes" "1 hour" -s -A
+15 minutes
 
 # mixed units between the two durations
 $ dtmate durmath "1 week" "3 days 12 hours" -s

--- a/cmd/dtmate/cmd/diff.go
+++ b/cmd/dtmate/cmd/diff.go
@@ -44,6 +44,7 @@ var optDiffBrief bool
 var optDiffReadFromStdin bool
 var optDiffConv string
 var optDiffDecimals int
+var optDiffAbsolute bool
 
 func init() {
 	rootCmd.AddCommand(diffCmd)
@@ -51,6 +52,7 @@ func init() {
 	diffCmd.Flags().BoolVarP(&optDiffReadFromStdin, "stdin", "i", false, "read from STDIN instead of using -s/-e")
 	diffCmd.Flags().StringVarP(&optDiffConv, "conv", "c", "", "convert resulting duration to another group of units")
 	diffCmd.Flags().IntVarP(&optDiffDecimals, "decimals", "d", 0, "with -c: show the smallest unit with this many decimal places, rounded")
+	diffCmd.Flags().BoolVarP(&optDiffAbsolute, "absolute", "A", false, "always output an absolute (positive) duration")
 }
 
 // either read one line containing a comma, then split start and end on this
@@ -89,7 +91,7 @@ func outputDiff(start, end string, brief bool) {
 		fmt.Fprintln(os.Stderr, "-d/--decimals requires -c/--conv")
 		os.Exit(1)
 	}
-	diff := DateTimeMate.NewDiff(DateTimeMate.DiffWithStart(start), DateTimeMate.DiffWithEnd(end), DateTimeMate.DiffWithBrief(brief))
+	diff := DateTimeMate.NewDiff(DateTimeMate.DiffWithStart(start), DateTimeMate.DiffWithEnd(end), DateTimeMate.DiffWithBrief(brief), DateTimeMate.DiffWithAbsolute(optDiffAbsolute))
 	result, _, err := diff.CalculateDiff()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/dtmate/cmd/durmath.go
+++ b/cmd/dtmate/cmd/durmath.go
@@ -1,7 +1,8 @@
 // durmath.go implements the 'durmath' sub-command, which adds or subtracts
 // two durations that may be expressed in different units. The operation is
 // selected with -a/--add or -s/--sub, and the signed result can optionally be
-// converted to target units (-c), rounded (-d), or output in brief form (-b).
+// converted to target units (-c), rounded (-d), output in brief form (-b),
+// or rendered as an absolute (positive) duration (-A).
 
 package cmd
 
@@ -33,6 +34,7 @@ var (
 	optDurMathConv     string
 	optDurMathBrief    bool
 	optDurMathDecimals int
+	optDurMathAbsolute bool
 )
 
 func init() {
@@ -42,6 +44,7 @@ func init() {
 	durMathCmd.Flags().StringVarP(&optDurMathConv, "conv", "c", "", "convert resulting duration to another group of units")
 	durMathCmd.Flags().BoolVarP(&optDurMathBrief, "brief", "b", false, "output in brief format, such as: 1Y3W4D5h6m7s")
 	durMathCmd.Flags().IntVarP(&optDurMathDecimals, "decimals", "d", 0, "with -c: show the smallest unit with this many decimal places, rounded")
+	durMathCmd.Flags().BoolVarP(&optDurMathAbsolute, "absolute", "A", false, "always output an absolute (positive) duration")
 	durMathCmd.MarkFlagsOneRequired("add", "sub")
 	durMathCmd.MarkFlagsMutuallyExclusive("add", "sub")
 	durMathCmd.SetFlagErrorFunc(negativeDurationHint("durmath", "Use -a/--add or -s/--sub to control the operation, e.g.:\n  dtmate durmath 2h 30m -s"))
@@ -60,7 +63,8 @@ func outputDurMath(first, second string) error {
 		DateTimeMate.DurMathWithSecond(second),
 		DateTimeMate.DurMathWithTarget(optDurMathConv),
 		DateTimeMate.DurMathWithBrief(optDurMathBrief),
-		DateTimeMate.DurMathWithDecimals(optDurMathDecimals))
+		DateTimeMate.DurMathWithDecimals(optDurMathDecimals),
+		DateTimeMate.DurMathWithAbsolute(optDurMathAbsolute))
 
 	var result string
 	var err error

--- a/diff.go
+++ b/diff.go
@@ -8,9 +8,10 @@ import (
 )
 
 type Diff struct {
-	Start string
-	End   string
-	Brief bool
+	Start    string
+	End      string
+	Brief    bool
+	Absolute bool
 }
 
 type OptionsDiff func(*Diff)
@@ -41,8 +42,16 @@ func DiffWithBrief(brief bool) OptionsDiff {
 	}
 }
 
+// DiffWithAbsolute makes CalculateDiff return an absolute (positive)
+// duration and formatted string regardless of argument order
+func DiffWithAbsolute(absolute bool) OptionsDiff {
+	return func(opt *Diff) {
+		opt.Absolute = absolute
+	}
+}
+
 func (diff *Diff) String() string {
-	return fmt.Sprintf("Start:%v End:%v Brief:%v", diff.Start, diff.End, diff.Brief)
+	return fmt.Sprintf("Start:%v End:%v Brief:%v Absolute:%v", diff.Start, diff.End, diff.Brief, diff.Absolute)
 }
 
 // parseDiffTime parses one side of a diff: 10-digit (seconds) and 13-digit
@@ -61,6 +70,7 @@ func parseDiffTime(source string) (time.Time, error) {
 
 // CalculateDiff return the time difference and also set dt.Diff
 // first try to parse with carbon, fallback to parsing with parsetime if carbon fails to parse
+// when Absolute is set, both the formatted string and the returned duration are non-negative
 func (diff *Diff) CalculateDiff() (string, time.Duration, error) {
 	start, err := parseDiffTime(diff.Start)
 	if err != nil {
@@ -77,6 +87,9 @@ func (diff *Diff) CalculateDiff() (string, time.Duration, error) {
 	}
 
 	duration := end.Sub(start)
+	if diff.Absolute {
+		duration = duration.Abs()
+	}
 	parsed := durafmt.Parse(duration)
 	difference := fmt.Sprintf("%v", parsed)
 	if diff.Brief {

--- a/diff_test.go
+++ b/diff_test.go
@@ -17,6 +17,46 @@ func testDiffStartEnd(t *testing.T, start, end string, brief bool, correct strin
 	}
 }
 
+// testDiffAbsolute mirrors testDiffStartEnd but also exercises the Absolute
+// option and asserts the sign of the returned time.Duration
+func testDiffAbsolute(t *testing.T, start, end string, brief, absolute bool, correct string, wantNegative bool) {
+	t.Helper()
+	diff := NewDiff(
+		DiffWithStart(start),
+		DiffWithEnd(end),
+		DiffWithBrief(brief),
+		DiffWithAbsolute(absolute))
+	result, duration, err := diff.CalculateDiff()
+	if err != nil {
+		t.Error(err)
+	}
+	if result != correct {
+		t.Errorf("[computed: %v] != [correct: %v]", result, correct)
+	}
+	if wantNegative && duration >= 0 {
+		t.Errorf("expected a negative duration, got: %v", duration)
+	}
+	if !wantNegative && duration < 0 {
+		t.Errorf("expected a non-negative duration, got: %v", duration)
+	}
+}
+
+func TestDiffSignedResult(t *testing.T) {
+	t.Parallel()
+	// the difference is signed when the start is later than the end
+	testDiffAbsolute(t, "15:30:45", "12:00:00", false, false, "-3 hours 30 minutes 45 seconds", true)
+	testDiffAbsolute(t, "15:30:45", "12:00:00", true, false, "-3h30m45s", true)
+}
+
+func TestDiffAbsoluteResult(t *testing.T) {
+	t.Parallel()
+	// Absolute makes both the formatted string and the returned duration positive
+	testDiffAbsolute(t, "15:30:45", "12:00:00", false, true, "3 hours 30 minutes 45 seconds", false)
+	testDiffAbsolute(t, "15:30:45", "12:00:00", true, true, "3h30m45s", false)
+	// Absolute is a no-op when the result is already positive
+	testDiffAbsolute(t, "12:00:00", "15:30:45", false, true, "3 hours 30 minutes 45 seconds", false)
+}
+
 func TestDiffTwoTimesSameDay(t *testing.T) {
 	t.Parallel()
 	start := "12:00:00"

--- a/durmath.go
+++ b/durmath.go
@@ -1,8 +1,9 @@
 // durmath.go implements duration arithmetic: adding or subtracting two
-// durations that may be expressed in different units. Results are signed and
-// rendered either as a largest-to-smallest breakdown from years down to
-// seconds (extended with sub-second units only when the result carries a
-// sub-second remainder) or converted to caller-specified target units.
+// durations that may be expressed in different units. Results are signed
+// (unless Absolute is set) and rendered either as a largest-to-smallest
+// breakdown from years down to seconds (extended with sub-second units only
+// when the result carries a sub-second remainder) or converted to
+// caller-specified target units.
 
 package DateTimeMate
 
@@ -23,12 +24,15 @@ var ErrNegativeDuration = errors.New("durmath does not accept negative durations
 // specific group of units; when empty, the result is a full breakdown from
 // years down to seconds. Brief renders compact output such as "2h15m".
 // Decimals sets the number of decimal places on the smallest output unit.
+// Absolute renders the result without a sign, e.g. -15 minutes becomes
+// 15 minutes.
 type DurMath struct {
 	First    string
 	Second   string
 	Target   string
 	Brief    bool
 	Decimals int
+	Absolute bool
 }
 
 // OptionsDurMath is a functional option used to configure a DurMath.
@@ -80,9 +84,17 @@ func DurMathWithDecimals(decimals int) OptionsDurMath {
 	}
 }
 
+// DurMathWithAbsolute makes Add and Sub return an absolute (positive)
+// duration; a negative result is rendered without the leading "-"
+func DurMathWithAbsolute(absolute bool) OptionsDurMath {
+	return func(dm *DurMath) {
+		dm.Absolute = absolute
+	}
+}
+
 // String returns a human-readable summary of the DurMath configuration.
 func (dm *DurMath) String() string {
-	return fmt.Sprintf("First:%v Second:%v Target:%v Brief:%v Decimals:%v", dm.First, dm.Second, dm.Target, dm.Brief, dm.Decimals)
+	return fmt.Sprintf("First:%v Second:%v Target:%v Brief:%v Decimals:%v Absolute:%v", dm.First, dm.Second, dm.Target, dm.Brief, dm.Decimals, dm.Absolute)
 }
 
 // Add returns the sum of the two durations.
@@ -91,7 +103,8 @@ func (dm *DurMath) Add() (string, error) {
 }
 
 // Sub returns the signed difference of the two durations, First minus Second;
-// a negative result is rendered with a single leading "-".
+// a negative result is rendered with a single leading "-" unless Absolute
+// is set.
 func (dm *DurMath) Sub() (string, error) {
 	return dm.compute(true)
 }
@@ -171,7 +184,7 @@ func (dm *DurMath) compute(subtract bool) (string, error) {
 		out = shrinkPeriod(out)
 	}
 	out = strings.TrimSpace(out)
-	if negative {
+	if negative && !dm.Absolute {
 		out = "-" + out
 	}
 	return out, nil

--- a/durmath_test.go
+++ b/durmath_test.go
@@ -1,7 +1,7 @@
 // durmath_test.go verifies the DurMath duration arithmetic API: adding and
-// subtracting durations across mixed units, signed results, target-unit
-// conversion, decimals, brief output, and rejection of invalid or negative
-// inputs.
+// subtracting durations across mixed units, signed results, absolute results,
+// target-unit conversion, decimals, brief output, and rejection of invalid or
+// negative inputs.
 package DateTimeMate
 
 import (
@@ -9,12 +9,13 @@ import (
 	"testing"
 )
 
-func testDurMath(t *testing.T, first, second string, brief bool, correctAdd, correctSub string) {
+func testDurMath(t *testing.T, first, second string, brief, absolute bool, correctAdd, correctSub string) {
 	t.Helper()
 	dm := NewDurMath(
 		DurMathWithFirst(first),
 		DurMathWithSecond(second),
-		DurMathWithBrief(brief))
+		DurMathWithBrief(brief),
+		DurMathWithAbsolute(absolute))
 
 	result, err := dm.Add()
 	if err != nil {
@@ -33,14 +34,15 @@ func testDurMath(t *testing.T, first, second string, brief bool, correctAdd, cor
 	}
 }
 
-func testDurMathConv(t *testing.T, first, second, target string, brief bool, decimals int, correctAdd, correctSub string) {
+func testDurMathConv(t *testing.T, first, second, target string, brief bool, decimals int, absolute bool, correctAdd, correctSub string) {
 	t.Helper()
 	dm := NewDurMath(
 		DurMathWithFirst(first),
 		DurMathWithSecond(second),
 		DurMathWithTarget(target),
 		DurMathWithBrief(brief),
-		DurMathWithDecimals(decimals))
+		DurMathWithDecimals(decimals),
+		DurMathWithAbsolute(absolute))
 
 	result, err := dm.Add()
 	if err != nil {
@@ -61,58 +63,84 @@ func testDurMathConv(t *testing.T, first, second, target string, brief bool, dec
 
 func TestDurMathHoursMinutes(t *testing.T) {
 	t.Parallel()
-	testDurMath(t, "1 hour 30 minutes", "45 minutes", false, "2 hours 15 minutes", "45 minutes")
-	testDurMath(t, "1h30m", "45m", false, "2 hours 15 minutes", "45 minutes")
-	testDurMath(t, "1h30m", "45m", true, "2h15m", "45m")
+	testDurMath(t, "1 hour 30 minutes", "45 minutes", false, false, "2 hours 15 minutes", "45 minutes")
+	testDurMath(t, "1h30m", "45m", false, false, "2 hours 15 minutes", "45 minutes")
+	testDurMath(t, "1h30m", "45m", true, false, "2h15m", "45m")
 }
 
 func TestDurMathSignedResult(t *testing.T) {
 	t.Parallel()
 	// subtraction is signed when the second duration is larger
-	testDurMath(t, "45 minutes", "1 hour", false, "1 hour 45 minutes", "-15 minutes")
-	testDurMath(t, "45 minutes", "1 hour", true, "1h45m", "-15m")
+	testDurMath(t, "45 minutes", "1 hour", false, false, "1 hour 45 minutes", "-15 minutes")
+	testDurMath(t, "45 minutes", "1 hour", true, false, "1h45m", "-15m")
+	// the sign also survives target-unit conversion
+	testDurMathConv(t, "90 minutes", "1 day", "minutes", false, 0, false, "1530 minutes", "-1350 minutes")
+}
+
+func TestDurMathAbsoluteResult(t *testing.T) {
+	t.Parallel()
+	// Absolute renders a negative result without the leading "-"
+	testDurMath(t, "45 minutes", "1 hour", false, true, "1 hour 45 minutes", "15 minutes")
+	testDurMath(t, "45 minutes", "1 hour", true, true, "1h45m", "15m")
+	// Absolute is a no-op on positive results
+	testDurMath(t, "1 hour 30 minutes", "45 minutes", false, true, "2 hours 15 minutes", "45 minutes")
+	// Absolute composes with target units and decimals
+	testDurMathConv(t, "90 minutes", "1 day", "minutes", false, 0, true, "1530 minutes", "1350 minutes")
+	testDurMathConv(t, "30 minutes", "1 hour", "hours", false, 1, true, "1.5 hours", "0.5 hours")
+	// a zero result still renders as "0 seconds", never "-0 seconds"
+	testDurMath(t, "1 hour", "60 minutes", false, true, "2 hours", "0 seconds")
+	testDurMath(t, "1 hour", "60 minutes", true, true, "2h", "0s")
+
+	// negative inputs are still rejected when Absolute is set
+	dm := NewDurMath(
+		DurMathWithFirst("1 year -30 days"),
+		DurMathWithSecond("1 hour"),
+		DurMathWithAbsolute(true))
+	if _, err := dm.Sub(); !errors.Is(err, ErrNegativeDuration) {
+		t.Errorf("expected ErrNegativeDuration with Absolute set, got: %v", err)
+	}
 }
 
 func TestDurMathMixedUnits(t *testing.T) {
 	t.Parallel()
-	testDurMath(t, "1 week", "3 days 12 hours", false, "1 week 3 days 12 hours", "3 days 12 hours")
-	testDurMath(t, "1 day", "90 minutes", false, "1 day 1 hour 30 minutes", "22 hours 30 minutes")
+	testDurMath(t, "1 week", "3 days 12 hours", false, false, "1 week 3 days 12 hours", "3 days 12 hours")
+	testDurMath(t, "1 day", "90 minutes", false, false, "1 day 1 hour 30 minutes", "22 hours 30 minutes")
 }
 
 func TestDurMathCaseInsensitiveUnits(t *testing.T) {
 	t.Parallel()
 	// long-form units are case-insensitive, singular or plural
-	testDurMath(t, "1 HOUR 30 Minutes", "45 MINUTES", false, "2 hours 15 minutes", "45 minutes")
+	testDurMath(t, "1 HOUR 30 Minutes", "45 MINUTES", false, false, "2 hours 15 minutes", "45 minutes")
 }
 
 func TestDurMathTargetUnits(t *testing.T) {
 	t.Parallel()
-	testDurMathConv(t, "1 day", "90 minutes", "minutes", false, 0, "1530 minutes", "1350 minutes")
+	testDurMathConv(t, "1 day", "90 minutes", "minutes", false, 0, false, "1530 minutes", "1350 minutes")
 	// brief target specification
-	testDurMathConv(t, "1 day", "90 minutes", "hm", false, 0, "25 hours 30 minutes", "22 hours 30 minutes")
-	testDurMathConv(t, "1 day", "90 minutes", "hm", true, 0, "25h30m", "22h30m")
+	testDurMathConv(t, "1 day", "90 minutes", "hm", false, 0, false, "25 hours 30 minutes", "22 hours 30 minutes")
+	testDurMathConv(t, "1 day", "90 minutes", "hm", true, 0, false, "25h30m", "22h30m")
 }
 
 func TestDurMathDecimals(t *testing.T) {
 	t.Parallel()
-	testDurMathConv(t, "1 hour", "30 minutes", "hours", false, 1, "1.5 hours", "0.5 hours")
-	testDurMathConv(t, "1 hour", "30 minutes", "hours", false, 2, "1.50 hours", "0.50 hours")
+	testDurMathConv(t, "1 hour", "30 minutes", "hours", false, 1, false, "1.5 hours", "0.5 hours")
+	testDurMathConv(t, "1 hour", "30 minutes", "hours", false, 2, false, "1.50 hours", "0.50 hours")
 }
 
 func TestDurMathSubSecond(t *testing.T) {
 	t.Parallel()
 	// sub-second units appear only when the result has a sub-second remainder
-	testDurMath(t, "1.5 seconds", "250 milliseconds", false, "1 second 750 milliseconds", "1 second 250 milliseconds")
-	testDurMath(t, "1 second", "500 milliseconds", false, "1 second 500 milliseconds", "500 milliseconds")
+	testDurMath(t, "1.5 seconds", "250 milliseconds", false, false, "1 second 750 milliseconds", "1 second 250 milliseconds")
+	testDurMath(t, "1 second", "500 milliseconds", false, false, "1 second 500 milliseconds", "500 milliseconds")
 	// whole-second results stay at second granularity
-	testDurMath(t, "750 milliseconds", "250 milliseconds", false, "1 second", "500 milliseconds")
+	testDurMath(t, "750 milliseconds", "250 milliseconds", false, false, "1 second", "500 milliseconds")
 }
 
 func TestDurMathZeroResult(t *testing.T) {
 	t.Parallel()
 	// a zero result renders as seconds, not nanoseconds
-	testDurMath(t, "1 hour", "60 minutes", false, "2 hours", "0 seconds")
-	testDurMath(t, "1 hour", "60 minutes", true, "2h", "0s")
+	testDurMath(t, "1 hour", "60 minutes", false, false, "2 hours", "0 seconds")
+	testDurMath(t, "1 hour", "60 minutes", true, false, "2h", "0s")
 }
 
 func TestDurMathInvalidInput(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR adds an opt-in `-A/--absolute` boolean flag to the `diff` and `durmath` verbs that always outputs an absolute (positive) duration. Without the flag, behavior is unchanged: `dtmate diff 15:30:45 12:00:00` yields `-3 hours 30 minutes 45 seconds` and `dtmate durmath "45 minutes" "1 hour" -s` yields `-15 minutes`. With the flag, the same invocations yield `3 hours 30 minutes 45 seconds` and `15 minutes`. The 1.9.0 durmath design (#40) deliberately kept results signed with no absolute-value mode; this PR adds absolute output only as an opt-in flag, so the signed default and existing scripts are unaffected. The capital `-A` shorthand is free in both commands; cobra shorthands are case-sensitive, so it does not collide with durmath's `-a/--add`.

## Behavior

For `diff`, `CalculateDiff()` applies `time.Duration.Abs()` immediately after computing the difference, so the formatted string, the brief (`-b`) string, the converted (`-c`) output, and the returned `time.Duration` are all non-negative. The `Abs()` MinInt64 edge case is unreachable because the existing 291-year cap rejects larger differences first. For `durmath`, the implementation suppresses only the final sign prepend in `compute()`; since the `-` was already applied after target-unit conversion, brief shrinking, and decimals, `-A` automatically composes with `-c`, `-b`, and `-d`. The `-c/--conv` path in both verbs is unaffected because `ConvertDuration` strips and re-applies a leading `-` independently, and an absolute input simply has none.

## Negative inputs unchanged

durmath still rejects negative duration inputs with `ErrNegativeDuration`, preserving the 1.9.0 double-negative-footgun guard: `-A` affects only the output sign, never input validation. `dtmate durmath "1 year -30 days" 1h -a -A` still errors with usage text.

## Library API

Following the established functional-options pattern, `Diff` gains an `Absolute` field with `DiffWithAbsolute(bool)`, and `DurMath` gains an `Absolute` field with `DurMathWithAbsolute(bool)`. Both are additive, backward-compatible changes; `String()` on both types now includes the new field.

## Testing

New library tests: `TestDiffSignedResult` (a previously missing baseline asserting signed diff output and a negative returned duration), `TestDiffAbsoluteResult` (absolute string and duration, plus a no-op check on already-positive results), and `TestDurMathAbsoluteResult` (absolute subtraction in long and brief form, no-op on positive results, composition with target units and decimals, zero-result rendering, and `ErrNegativeDuration` identity under Absolute). `TestDurMathSignedResult` also gains a signed target-unit conversion case. The durmath test helpers were extended with an `absolute` parameter. Verified with `go build ./...`, `go vet ./...`, `go test ./...`, and end-to-end CLI runs of signed vs `-A` output for both verbs including brief, conv, stdin, and negative-input paths.

## Other changes

`ModVersion` bumped to 1.10.0. README updated with signed/absolute example pairs for both verbs in the embedded Command Line Examples (feeds `dtmate -e`) and an `-A` line in the intro inquiry list.
