### PR TITLE
Fix Conv receiver mutation and remove no-op Dur.Op field; bump version to 1.11.0

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,0 +1,95 @@
+# Known bugs in the Go module programming interface (as of v1.8.0)
+
+**Status update (v1.11.0):** Both bugs are resolved. Bug 1's brief-expansion overwrite had already been fixed by the `parseDurationSeconds()` refactor, and the remaining sign-strip mutation in `ConvertDuration()` now operates on a local copy of `Source` (regression test: `TestConvReuse` in `conv_test.go`). Bug 2 was resolved by removing the `Dur.Op` field and unexporting the `Add`/`Sub` constants (now internal `opAdd`/`opSub`); `String()` no longer prints an op. The removal is technically API-breaking, but the field was a silent no-op and nothing external is known to set it, so it shipped as a minor bump (1.11.0) rather than a /v2 major.
+
+These two issues affect only consumers of the `github.com/jftuga/DateTimeMate` Go module. The `dtmate` CLI never hits them because it constructs each object once, uses it once, and exits. Both were found during the v1.8.0 bug hunt (PR #36) by exercising the library as an external module consumer; neither is covered by the existing test suite. Work on branch `bug-hunt-2`.
+
+## Bug 1: Conv.ConvertDuration() mutates its receiver, silently losing the negative sign on reuse
+
+### Severity
+
+High for library users: silent wrong result, same class as the P1 bugs fixed in v1.8.0.
+
+### Reproduction
+
+```go
+package main
+
+import (
+	"fmt"
+	DateTimeMate "github.com/jftuga/DateTimeMate"
+)
+
+func main() {
+	conv := DateTimeMate.NewConv(
+		DateTimeMate.ConvWithSource("-90m"),
+		DateTimeMate.ConvWithTarget("hours"))
+	r1, _ := conv.ConvertDuration()
+	r2, _ := conv.ConvertDuration()
+	fmt.Println(r1) // "-1 hour"  correct
+	fmt.Println(r2) // "1 hour"   WRONG: the negative sign is gone
+}
+```
+
+Any reuse of a `*Conv` is affected. The second and subsequent calls on a negative source return a positive result. A brief source (e.g. "90m") is also rewritten in place to its expanded long form ("90 minutes"), which happens to still parse correctly, so the sign loss is the observable wrong result; the in-place rewriting is the root defect.
+
+### Root cause
+
+`ConvertDuration()` in `conv.go` writes back to the struct instead of working on a local copy:
+
+- `conv.go:273-274` — `strings.CutPrefix(conv.Source, "-")` strips the leading minus and assigns the stripped string back to `conv.Source`. The `isNegativeDuration` flag that remembers the sign is a local variable, so the sign is permanently lost from the struct after the first call.
+- `conv.go:283` — after brief expansion, `conv.Source = expandedSource` overwrites the original source with the expanded long form.
+- `parseSource()` (`conv.go:104`) reads `conv.Source` from the struct, which is why the mutations were introduced in the first place.
+
+### Suggested fix
+
+Make `ConvertDuration()` operate on a local `source` string. Two mechanical options; option A is less invasive:
+
+- Option A: change `parseSource()` to accept the source as a parameter, `func (conv *Conv) parseSource(source string) (float64, error)`, and thread a local variable through `ConvertDuration()` (local `source := conv.Source`, strip the minus into `isNegativeDuration`, expand brief format into the local, never assign to `conv.Source`).
+- Option B: keep signatures and save/restore `conv.Source` with a `defer`. Rejected style-wise: it keeps the mutation window open and is fragile.
+
+Audit the sibling types for the same pattern while there: `Diff.CalculateDiff()` (diff.go) and `Dur.addOrSub()` (dur.go) do NOT mutate their receivers — verified during the hunt, and `dur_test.go` already reuses one `Dur` for both `Add()` and `Sub()`.
+
+### Regression test
+
+Add to `conv_test.go`, following the existing `testConv` helper style: construct one `Conv` with source "-90m" target "hours", call `ConvertDuration()` twice, assert both calls return "-1 hour". Also assert a second call with a brief positive source ("90m" -> "1 hour") still works, to cover the brief-expansion overwrite.
+
+## Bug 2: Dur.Op is an exported field that is silently ignored
+
+### Severity
+
+Low-to-medium: no wrong arithmetic by itself, but it is a misleading API contract that invites wrong code.
+
+### Reproduction
+
+```go
+dur := DateTimeMate.Dur{From: "2024-01-01", Op: DateTimeMate.Sub, Period: "1 day"}
+res, _ := dur.Add()
+fmt.Println(res) // [2024-01-02 ...] — it ADDED, even though Op says Sub
+```
+
+### Root cause
+
+- `dur.go:22` — `Dur` has an exported `Op int` field, and `dur.go:16-18` exports the `Add`/`Sub` constants that look like its intended values.
+- `Dur.Add()` and `Dur.Sub()` pass their own hardcoded op constant to `addOrSub()` and never read `dur.Op`. Nothing else reads it either, except `String()` (`dur.go:108`) which prints it, reinforcing the impression that it matters.
+- There is also no `DurWithOp()` functional option, unlike every other `Dur` field.
+
+### Decision needed before fixing
+
+Pick one, in descending order of preference:
+
+1. Wire it up without breaking anyone: add a `Compute() ([]string, error)` method that dispatches on `dur.Op` (`Add` -> add, `Sub` -> subtract, anything else -> error), add a `DurWithOp(op int)` option, and have `Add()`/`Sub()` set `dur.Op` before delegating so `String()` output stays truthful. Existing callers are unaffected.
+2. Remove/unexport the field. Honest but a compile-time breaking change for any consumer who sets `Op` (harmlessly today); would warrant a version bump discussion.
+3. Document-only: comment the field as informational. Weakest option since it leaves the trap in place.
+
+If option 1 is chosen, note that the `Add`/`Sub` constants at `dur.go:16-18` are untyped iota ints; consider giving them a named type (e.g. `type Op int`) for the `DurWithOp` signature, but weigh that against breaking `Dur{Op: 1}` literals.
+
+### Regression test
+
+Whichever option is chosen: a test that constructs a `Dur` with `Op` set and asserts the chosen contract (e.g. `Compute()` subtracts when `Op == Sub`, and `Add()` still adds regardless).
+
+## Verification for both fixes
+
+1. `go test ./...` passes (74 existing tests plus the new ones) — run under `TZ=UTC` and `TZ=America/New_York` at minimum.
+2. `go vet ./...` clean.
+3. Rebuild the CLI (`go build ./cmd/dtmate`) and spot-check `dtmate conv -- -90m h` still prints "-1 hour", since the CLI shares these code paths.

--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -21,7 +21,7 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.10.0"
+	ModVersion string = "1.11.0"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 

--- a/DateTimeMate_test.go
+++ b/DateTimeMate_test.go
@@ -101,13 +101,14 @@ func TestFormatCommand(t *testing.T) {
 	correct = "1718560862"
 	testFormat(t, source, fmt, correct)
 
+	// unix timestamps render in local time, so compute the expected
+	// value dynamically to keep this test timezone-independent
 	source = "1704085262"
 	fmt = "%F %T"
-	correct = "2024-01-01 00:01:02"
+	correct = time.Unix(1704085262, 0).Format("2006-01-02 15:04:05")
 	testFormat(t, source, fmt, correct)
 
 	source = "1704085262999"
 	fmt = "%F %T"
-	correct = "2024-01-01 00:01:02"
 	testFormat(t, source, fmt, correct)
 }

--- a/conv.go
+++ b/conv.go
@@ -309,12 +309,13 @@ func (conv *Conv) ConvertDuration() (string, error) {
 	if conv.Decimals < 0 || conv.Decimals > 9 {
 		return "", fmt.Errorf("decimals must be between 0 and 9: %d", conv.Decimals)
 	}
+	source := conv.Source
 	isNegativeDuration := false
-	if s, found := strings.CutPrefix(conv.Source, "-"); found {
-		conv.Source = s
+	if s, found := strings.CutPrefix(source, "-"); found {
+		source = s
 		isNegativeDuration = true
 	}
-	seconds, err := parseDurationSeconds(conv.Source)
+	seconds, err := parseDurationSeconds(source)
 	if err != nil {
 		return "", err
 	}

--- a/conv_test.go
+++ b/conv_test.go
@@ -313,3 +313,35 @@ func TestConvNanoseconds1(t *testing.T) {
 	correct = "-39Y6W2D5h31m30s987ms654us447ns"
 	testConv(t, source, target, true, correct)
 }
+
+// TestConvReuse guards against ConvertDuration mutating its receiver:
+// reusing one Conv must return identical results on every call,
+// including the negative sign and the original brief source format
+func TestConvReuse(t *testing.T) {
+	t.Parallel()
+	conv := NewConv(
+		ConvWithSource("-90m"),
+		ConvWithTarget("hours"))
+	for i := 0; i < 2; i++ {
+		result, err := conv.ConvertDuration()
+		if err != nil {
+			t.Error(err)
+		}
+		if result != "-1 hour" {
+			t.Errorf("call %d:\n[computed: %v] !=\n[correct : -1 hour]", i+1, result)
+		}
+	}
+
+	conv = NewConv(
+		ConvWithSource("90m"),
+		ConvWithTarget("hours"))
+	for i := 0; i < 2; i++ {
+		result, err := conv.ConvertDuration()
+		if err != nil {
+			t.Error(err)
+		}
+		if result != "1 hour" {
+			t.Errorf("call %d:\n[computed: %v] !=\n[correct : 1 hour]", i+1, result)
+		}
+	}
+}

--- a/dur.go
+++ b/dur.go
@@ -11,15 +11,14 @@ import (
 	"time"
 )
 
-// used for Dur.Op
+// internal operation selectors for addOrSub
 const (
-	Add = iota
-	Sub
+	opAdd = iota
+	opSub
 )
 
 type Dur struct {
 	From         string
-	Op           int
 	Period       string
 	Repeat       int
 	Until        string
@@ -105,15 +104,15 @@ func DurWithOutputFormat(outputFormat string) OptionsDur {
 }
 
 func (dur *Dur) String() string {
-	return fmt.Sprintf("From:%v Period:%v Op:%v, Repeat:%v Until:%v OutputFormat:%v", dur.From, dur.Period, dur.Op, dur.Repeat, dur.Until, dur.OutputFormat)
+	return fmt.Sprintf("From:%v Period:%v Repeat:%v Until:%v OutputFormat:%v", dur.From, dur.Period, dur.Repeat, dur.Until, dur.OutputFormat)
 }
 
 func (dur *Dur) Add() ([]string, error) {
-	return dur.addOrSub(Add)
+	return dur.addOrSub(opAdd)
 }
 
 func (dur *Dur) Sub() ([]string, error) {
-	return dur.addOrSub(Sub)
+	return dur.addOrSub(opSub)
 }
 
 // addOrSub - calculates a date/time when given a starting date/time and a duration
@@ -175,7 +174,7 @@ func (dur *Dur) addOrSub(op int) ([]string, error) {
 				return nil, fmt.Errorf("duration %q does not advance toward the until date/time", dur.Period)
 			}
 			to = next
-			if Add == op {
+			if opAdd == op {
 				if to.StdTime().After(u) {
 					break
 				}


### PR DESCRIPTION
## Summary

This PR resolves the two Go-module-API bugs documented in BUGS.md from the v1.8.0 bug hunt, verified to still be present in v1.10.0. Both issues affect only library consumers of `github.com/jftuga/DateTimeMate`; the `dtmate` CLI constructs each object once and exits, so it never hits them.

## Bug 1: Conv.ConvertDuration() mutated its receiver, silently losing the negative sign on reuse

`ConvertDuration()` stripped a leading minus from `conv.Source` with `strings.CutPrefix` and wrote the stripped string back to the struct, while the `isNegativeDuration` flag lived in a local variable. The first call on a source such as `-90m` correctly returned `-1 hour`, but every subsequent call on the same `*Conv` returned `1 hour` because the sign was permanently gone from the struct. The fix threads a local `source` variable through the function so the receiver is never modified. The brief-expansion overwrite noted in the original report had already been fixed by the earlier `parseDurationSeconds()` refactor. A new regression test, `TestConvReuse` in conv_test.go, calls `ConvertDuration()` twice on one `Conv` for both a negative brief source (`-90m` must yield `-1 hour` both times) and a positive brief source (`90m` must yield `1 hour` both times).

## Bug 2: Dur.Op was an exported field that was silently ignored

`Dur` exported an `Op int` field alongside exported `Add`/`Sub` constants that looked like its intended values, but `Dur.Add()` and `Dur.Sub()` hardcoded their operation and nothing ever read `dur.Op` except `String()`, which printed it and reinforced the false impression that it mattered. Setting `Dur{Op: Sub}` and calling `Add()` still added. The field has been removed, the `Add`/`Sub` constants are now the internal `opAdd`/`opSub`, and `String()` no longer prints an op. Nothing in the README, tests, or CLI referenced any of these symbols. This is technically a breaking API change, but since the field was a silent no-op that no known consumer sets, it ships as a minor version bump rather than a /v2 major.

## Additional test fix

Verification under multiple timezones exposed a pre-existing, unrelated failure: `TestFormatCommand` hardcoded the US-Eastern local rendering of unix timestamp `1704085262`, so it failed under `TZ=UTC` even on the unmodified code. The expected value is now computed dynamically with `time.Unix(...).Format(...)`, matching the pattern already used in `TestReformatWinterUnixSeconds`, making the test timezone-independent.

## Verification

`go vet ./...` is clean and all 125 tests pass under both `TZ=UTC` and `TZ=America/New_York`. The rebuilt CLI prints `-1 hour` for `dtmate conv -- -90m h` and reports version 1.11.0. A grep confirms no `.Op` references remain in any Go file. BUGS.md has been updated with a status header recording both resolutions.
