### PR TITLE
 Fix 19 bugs across fmt, dur, diff, conv, and durmath; bump version to 1.13.0

### DIFF
--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -3,6 +3,8 @@ package DateTimeMate
 import (
 	_ "embed"
 	"fmt"
+	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -21,9 +23,17 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.12.0"
+	ModVersion string = "1.13.0"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
+
+// DateOrderEnvVar names the environment variable that controls how an
+// ambiguous slash-separated date such as "01/02/2024" is interpreted:
+// "MDY" (month/day/year, the default) or "DMY" (day/month/year).
+// Unambiguous dates such as "25/12/2024" parse the same way regardless of
+// this variable. When an ambiguous date is parsed and the variable is not
+// set, a warning naming the variable is written to stderr.
+const DateOrderEnvVar = "DTMATE_DATE_ORDER"
 
 // this type of data structure is needed to preserve order as
 // replacement always needs to be performed in this order
@@ -60,9 +70,12 @@ func ConvertRelativeDateToActual(from string) string {
 	case "today":
 		return carbon.Now().String()
 	case "yesterday":
-		return carbon.Yesterday().String()
+		// SubHours keeps the documented "exactly 24 hours" promise; SubDay
+		// is calendar-day arithmetic, which is 23 or 25 real hours on the
+		// two DST transition days
+		return carbon.Now().SubHours(24).String()
 	case "tomorrow":
-		return carbon.Tomorrow().String()
+		return carbon.Now().AddHours(24).String()
 	}
 	return from
 }
@@ -96,18 +109,128 @@ func fixLocalZone(t time.Time) time.Time {
 	return t
 }
 
+// zoneOffsetRegexp matches a numeric UTC offset written into a date/time
+// string, such as "+0500", "-04:30", or "-0400": a sign followed by two
+// digits, an optional colon, and two more digits; the separators inside
+// dates like "2024-10-15" never have four digits after the sign, so plain
+// dates cannot match
+var zoneOffsetRegexp = regexp.MustCompile(`[+-][0-9]{2}:?[0-9]{2}`)
+
+// sourceHasExplicitZone reports whether the source text itself names the
+// zone found on the parsed time, either by abbreviation (e.g. "EDT") or as
+// a numeric UTC offset; fixLocalZone must leave such times alone because
+// their zone was written by the user, not stamped on by parsetime
+func sourceHasExplicitZone(source string, t time.Time) bool {
+	if name, _ := t.Zone(); name != "" && strings.Contains(source, name) {
+		return true
+	}
+	return zoneOffsetRegexp.MatchString(source)
+}
+
 // wallClockLayouts are zone-less layouts interpreted in the local time
 // zone; they are tried before parsetime because parsetime silently
-// corrupts pre-1970 date/times
-var wallClockLayouts = []string{"2006-01-02 15:04:05", "2006-01-02T15:04:05", "2006-01-02 15:04", "2006-01-02"}
+// corrupts pre-1970 date/times; the 14-digit compact layout is included
+// so it parses deterministically instead of relying on parsetime, whose
+// year-mismatch guard cannot see a year inside a 14-digit run
+var wallClockLayouts = []string{"2006-01-02 15:04:05", "2006-01-02T15:04:05", "2006-01-02 15:04", "2006-01-02", "20060102150405"}
 
 // zonedLayouts carry their own zone or offset, which must be preserved in
 // the result (e.g. reformatting "...Z" with %Z must print UTC, not local)
 var zonedLayouts = []string{time.RFC3339Nano, "2006-01-02 15:04:05 -0700 MST", "2006-01-02 15:04:05 -0700", "2006-01-02 15:04:05 MST", time.UnixDate, time.RFC1123Z, time.RFC1123, time.RubyDate}
 
+// isAllDigits reports whether s is non-empty and contains only ASCII digits
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// slashDateFields splits the leading token of source into the two 1-2 digit
+// fields and 4-digit year of a slash-separated date such as "01/02/2024" or
+// "1/2/2024 08:30"; ok is false when the token does not have that shape
+func slashDateFields(source string) (first, second int, ok bool) {
+	token := source
+	if i := strings.IndexAny(token, " T"); i != -1 {
+		token = token[:i]
+	}
+	parts := strings.Split(token, "/")
+	if len(parts) != 3 {
+		return 0, 0, false
+	}
+	if len(parts[0]) > 2 || len(parts[1]) > 2 || len(parts[2]) != 4 {
+		return 0, 0, false
+	}
+	for _, part := range parts {
+		if !isAllDigits(part) {
+			return 0, 0, false
+		}
+	}
+	first, _ = strconv.Atoi(parts[0])
+	second, _ = strconv.Atoi(parts[1])
+	return first, second, true
+}
+
+// slashDateTimeSuffixes are the time-of-day layouts accepted after a
+// slash-separated date; the empty suffix accepts a bare date
+var slashDateTimeSuffixes = []string{"", " 15:04:05", "T15:04:05", " 15:04", " 3:04:05PM", " 3:04PM"}
+
+// parseSlashDate parses slash-separated dates, whose field order the layered
+// parsers disagree on: month first (the default) or day first when
+// DateOrderEnvVar is set to "DMY". A field greater than 12 disambiguates on
+// its own, regardless of the variable; an ambiguous date parsed with the
+// variable unset triggers a stderr warning naming it. The claimed return
+// reports whether the input has the slash-date shape at all; when true the
+// caller must not try other parsers, so that no shape can silently fall
+// through to a parser with a different field order.
+func parseSlashDate(source string) (time.Time, bool, error) {
+	first, second, ok := slashDateFields(source)
+	if !ok {
+		return time.Time{}, false, nil
+	}
+	var monthFirst bool
+	switch {
+	case first > 12 && second > 12:
+		return time.Time{}, true, fmt.Errorf("invalid date %q: neither %d nor %d can be a month", source, first, second)
+	case first > 12:
+		monthFirst = false
+	case second > 12:
+		monthFirst = true
+	default:
+		order := strings.ToUpper(strings.TrimSpace(os.Getenv(DateOrderEnvVar)))
+		switch order {
+		case "", "MDY":
+			if order == "" {
+				fmt.Fprintf(os.Stderr, "warning: %q is ambiguous: interpreting as month/day/year; set %s=DMY to override\n", source, DateOrderEnvVar)
+			}
+			monthFirst = true
+		case "DMY":
+			monthFirst = false
+		default:
+			return time.Time{}, true, fmt.Errorf("%s must be MDY or DMY, not %q", DateOrderEnvVar, order)
+		}
+	}
+	dateLayout := "1/2/2006"
+	if !monthFirst {
+		dateLayout = "2/1/2006"
+	}
+	for _, suffix := range slashDateTimeSuffixes {
+		if t, err := time.ParseInLocation(dateLayout+suffix, source, time.Local); err == nil {
+			return t, true, nil
+		}
+	}
+	return time.Time{}, true, fmt.Errorf("unable to parse date/time: %q", source)
+}
+
 // parseDateTime parses a date/time string: standard layouts are tried
 // first because they preserve explicit zones and handle any year, then
-// parsetime (with fixLocalZone correcting the DST offset of zone-less
+// slash-separated dates (whose field order is settled by DateOrderEnvVar),
+// then parsetime (with fixLocalZone correcting the DST offset of zone-less
 // strings), and finally carbon; parsetime results naming a year that does
 // not appear in the input are rejected as corrupt rather than returned
 func parseDateTime(source string) (time.Time, error) {
@@ -121,12 +244,18 @@ func parseDateTime(source string) (time.Time, error) {
 			return t, nil
 		}
 	}
+	if t, claimed, err := parseSlashDate(source); claimed {
+		return t, err
+	}
 	p, err := parsetime.NewParseTime()
 	if err != nil {
 		return time.Time{}, err
 	}
 	t, err := p.Parse(source)
 	if err == nil && !parsedYearMismatch(source, t) {
+		if sourceHasExplicitZone(source, t) {
+			return t, nil
+		}
 		return fixLocalZone(t), nil
 	}
 	if c := carbon.Parse(source); c.Error == nil {
@@ -194,41 +323,45 @@ func Reformat(source string, outputFormat string) (string, error) {
 		return "", err
 	}
 
-	var t time.Time
-	if isPureIntegerAtoi(source) {
-		if source[0] == '-' {
-			return "", fmt.Errorf("timestamps can't be negative: %v", source)
-		}
-		t, err = unixStringToTime(source)
-	} else {
-		t, err = parseDateTime(ConvertRelativeDateToActual(source))
-	}
+	t, err := parseDateTimeOrUnix(source)
 	if err != nil {
 		return "", err
 	}
 	return f.FormatString(t), nil
 }
 
+// timestampDigits returns the number of digits in a pure integer string,
+// ignoring any leading sign
+func timestampDigits(s string) int {
+	s = strings.TrimPrefix(s, "+")
+	s = strings.TrimPrefix(s, "-")
+	return len(s)
+}
+
 // unixStringToTime converts a string containing a Unix timestamp to time.Time.
 // It accepts timestamps in seconds (up to 10 digits) and milliseconds (13 digits).
 // Returns the corresponding time.Time and any error encountered during conversion.
 //
-// If the input string is not a valid integer, is empty, or has an ambiguous
-// length (11, 12, or more than 13 digits), it returns a zero time.Time and an error.
+// If the input string is not a valid integer, is empty, is negative, or has an
+// ambiguous digit count (11, 12, or more than 13 digits), it returns a zero
+// time.Time and an error.
 func unixStringToTime(timestamp string) (time.Time, error) {
 	timestamp = strings.TrimSpace(timestamp)
 	unixTime, err := strconv.ParseInt(timestamp, 10, 64)
 	if err != nil {
 		return time.Time{}, err
 	}
+	if unixTime < 0 {
+		return time.Time{}, fmt.Errorf("timestamps can't be negative: %v", timestamp)
+	}
 
-	switch {
-	case len(timestamp) <= 10:
+	switch digits := timestampDigits(timestamp); {
+	case digits <= 10:
 		return time.Unix(unixTime, 0), nil
-	case len(timestamp) == 13:
+	case digits == 13:
 		return time.UnixMilli(unixTime), nil
 	default:
-		return time.Time{}, fmt.Errorf("ambiguous timestamp length %d for %q: expected up to 10 digits (seconds) or exactly 13 (milliseconds)", len(timestamp), timestamp)
+		return time.Time{}, fmt.Errorf("ambiguous timestamp length %d for %q: expected up to 10 digits (seconds) or exactly 13 (milliseconds)", digits, timestamp)
 	}
 }
 
@@ -240,22 +373,56 @@ func isPureIntegerAtoi(s string) bool {
 }
 
 // isUnixTimestamp reports whether a string should be treated as a Unix
-// timestamp: a pure integer of 10 to 13 characters; 10 characters are
-// seconds and 13 are milliseconds, while ambiguous 11 and 12 character
-// values are rejected with an error by unixStringToTime instead of falling
-// through to the date/time parser; other lengths are excluded so values
-// such as "2024" or a 14-digit compact date/time like "20240101080102"
-// are still parsed as date/times
+// timestamp: a pure integer of 10 to 13 digits; 10 digits are seconds and
+// 13 are milliseconds, while ambiguous 11 and 12 digit values are rejected
+// with an error by unixStringToTime instead of falling through to the
+// date/time parser; other digit counts are excluded so values such as
+// "2024" or a 14-digit compact date/time like "20240101080102" are still
+// parsed as date/times
 func isUnixTimestamp(s string) bool {
-	return isPureIntegerAtoi(s) && len(s) >= 10 && len(s) <= 13
+	digits := timestampDigits(s)
+	return isPureIntegerAtoi(s) && digits >= 10 && digits <= 13
+}
+
+// parseIntegerDateTime parses a pure-integer date/time that is not a Unix
+// timestamp: 4 digits are a year, 8 digits a compact date, and 14 digits a
+// compact date/time, all interpreted in the local time zone; any other
+// digit count errors rather than falling through to a parser that would
+// misread the digits as a time of day on the current date
+func parseIntegerDateTime(source string) (time.Time, error) {
+	var layout string
+	switch timestampDigits(source) {
+	case 4:
+		layout = "2006"
+	case 8:
+		layout = "20060102"
+	case 14:
+		layout = "20060102150405"
+	default:
+		return time.Time{}, fmt.Errorf("ambiguous integer date/time %q: expected 4 digits (year), 8 (date), 10 (seconds), 13 (milliseconds), or 14 (date/time)", source)
+	}
+	t, err := time.ParseInLocation(layout, source, time.Local)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("unable to parse integer date/time %q: %w", source, err)
+	}
+	return t, nil
 }
 
 // parseDateTimeOrUnix parses a date/time string, treating 10-digit (seconds)
-// and 13-digit (milliseconds) integers as Unix timestamps; anything else is
-// converted from a relative date and parsed with parsetime
+// and 13-digit (milliseconds) integers as Unix timestamps; negative integers
+// are rejected because timestamps can't be negative, other integers are
+// parsed as compact date/times, and anything else is converted from a
+// relative date and parsed as a date/time
 func parseDateTimeOrUnix(source string) (time.Time, error) {
-	if isUnixTimestamp(source) {
-		return unixStringToTime(source)
+	source = strings.TrimSpace(source)
+	if isPureIntegerAtoi(source) {
+		if strings.HasPrefix(source, "-") {
+			return time.Time{}, fmt.Errorf("timestamps can't be negative: %v", source)
+		}
+		if isUnixTimestamp(source) {
+			return unixStringToTime(source)
+		}
+		return parseIntegerDateTime(source)
 	}
 	return parseDateTime(ConvertRelativeDateToActual(source))
 }

--- a/DateTimeMate_test.go
+++ b/DateTimeMate_test.go
@@ -24,11 +24,158 @@ func TestReformatWinterUnixSeconds(t *testing.T) {
 }
 
 func TestReformatAmbiguousTimestampLength(t *testing.T) {
-	// 11, 12, and 14+ digit integers are neither seconds nor milliseconds
-	for _, source := range []string{"12345678901", "123456789012", "12345678901234"} {
+	// 11 and 12 digit integers are neither seconds nor milliseconds; a
+	// 14-digit integer is a compact date/time, so one that is not a valid
+	// date/time errors instead of falling through to a lenient parser
+	for _, source := range []string{"12345678901", "123456789012", "12345678901234", "123456"} {
 		if _, err := Reformat(source, "%F"); err == nil {
 			t.Errorf("expected an error for timestamp %q, got nil", source)
 		}
+	}
+}
+
+func TestReformatIntegerDate(t *testing.T) {
+	// pure integers that are not unix timestamps parse as compact
+	// date/times instead of being misread as epoch seconds
+	testFormat(t, "2024", "%Y", "2024")
+	testFormat(t, "20240101", "%F", "2024-01-01")
+	testFormat(t, "20240101080102", "%F %T", "2024-01-01 08:01:02")
+}
+
+func TestNegativeTimestampRejected(t *testing.T) {
+	// negative integers are rejected everywhere as negative timestamps
+	for _, source := range []string{"-170000000", "-1700265600", "-17000000000"} {
+		if _, err := Reformat(source, "%s"); err == nil {
+			t.Errorf("Reformat: expected an error for %q, got nil", source)
+		}
+		dur := NewDur(DurWithFrom(source), DurWithDur("1 second"))
+		if _, err := dur.Add(); err == nil {
+			t.Errorf("Dur: expected an error for %q, got nil", source)
+		}
+		diff := NewDiff(DiffWithStart(source), DiffWithEnd("2024-01-01"))
+		if _, _, err := diff.CalculateDiff(); err == nil {
+			t.Errorf("Diff: expected an error for %q, got nil", source)
+		}
+	}
+
+	// the ambiguous-length error counts digits, not characters: an 11-digit
+	// negative value must be rejected as negative, never reported as length 12
+	_, err := Reformat("-17000000000", "%s")
+	if err == nil || !strings.Contains(err.Error(), "negative") {
+		t.Errorf("expected a negative-timestamp error, got: %v", err)
+	}
+}
+
+func TestTimestampLeadingWhitespace(t *testing.T) {
+	// leading whitespace must not bypass the unix-timestamp gate and let a
+	// lenient parser misread the digits as a time of day
+	testFormat(t, " 1700265600", "%s", "1700265600")
+
+	dur := NewDur(DurWithFrom(" 1700265600"), DurWithDur("0 seconds"), DurWithOutputFormat("%s"))
+	future, err := dur.Add()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(future) != 1 || future[0] != "1700265600" {
+		t.Errorf("[computed: %v] != [correct: 1700265600]", future)
+	}
+
+	diff := NewDiff(DiffWithStart(" 1700265600"), DiffWithEnd("1700265600"))
+	_, duration, err := diff.CalculateDiff()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if duration != 0 {
+		t.Errorf("[computed: %v] != [correct: 0s]", duration)
+	}
+}
+
+func TestSlashDateOrder(t *testing.T) {
+	// no t.Parallel: t.Setenv is process-wide
+	// ambiguous slash dates default to month/day/year
+	t.Setenv(DateOrderEnvVar, "")
+	testFormat(t, "01/02/2024", "%F", "2024-01-02")
+	testFormat(t, "1/2/2024", "%F", "2024-01-02")
+	testFormat(t, "01/02/2024 08:30", "%F %H:%M", "2024-01-02 08:30")
+	testFormat(t, "01/02/2024 08:30:15", "%F %T", "2024-01-02 08:30:15")
+
+	// DMY flips ambiguous dates to day/month/year
+	t.Setenv(DateOrderEnvVar, "DMY")
+	testFormat(t, "01/02/2024", "%F", "2024-02-01")
+	testFormat(t, "1/2/2024", "%F", "2024-02-01")
+
+	// a field greater than 12 disambiguates on its own, regardless of the variable
+	testFormat(t, "25/12/2024", "%F", "2024-12-25")
+	t.Setenv(DateOrderEnvVar, "MDY")
+	testFormat(t, "25/12/2024", "%F", "2024-12-25")
+	testFormat(t, "12/25/2024", "%F", "2024-12-25")
+
+	// an invalid value errors only when an ambiguous date is actually parsed
+	t.Setenv(DateOrderEnvVar, "YMD")
+	if _, err := Reformat("01/02/2024", "%F"); err == nil {
+		t.Error("expected an error for an invalid date-order value, got nil")
+	}
+	testFormat(t, "25/12/2024", "%F", "2024-12-25")
+
+	// neither field can be a month
+	t.Setenv(DateOrderEnvVar, "")
+	if _, err := Reformat("13/13/2024", "%F"); err == nil {
+		t.Error("expected an error when neither slash-date field can be a month, got nil")
+	}
+}
+
+func TestParserAgreement(t *testing.T) {
+	// no t.Parallel: TestSlashDateOrder mutates the date-order variable
+	// Diff and Dur/Reformat must assign the same instant to the same input
+	// (they used to try carbon and parsetime in opposite orders)
+	for _, source := range []string{"01/02/2024", "1/2/2024", "2024-01", "20240101080102", "Jan 2, 2024"} {
+		viaReformat, err := Reformat(source, "%s")
+		if err != nil {
+			t.Fatalf("Reformat(%q): %v", source, err)
+		}
+		sec, err := strconv.ParseInt(viaReformat, 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		diff := NewDiff(DiffWithStart(source), DiffWithEnd(strconv.FormatInt(sec, 10)))
+		_, duration, err := diff.CalculateDiff()
+		if err != nil {
+			t.Fatalf("Diff(%q): %v", source, err)
+		}
+		if duration != 0 {
+			t.Errorf("parsers disagree on %q by %v", source, duration)
+		}
+	}
+}
+
+func TestExplicitZonePreservedAcrossDST(t *testing.T) {
+	// fixLocalZone used to reinterpret times whose explicit zone matched
+	// today's abbreviation, shifting instants across a DST boundary; probe
+	// with today's zone abbreviation on a date in the opposite DST regime,
+	// using a format that is not covered by zonedLayouts
+	now := time.Now()
+	name, offset := now.Zone()
+	var probe time.Time
+	for month := time.January; month <= time.December; month++ {
+		candidate := time.Date(now.Year(), month, 15, 12, 0, 0, 0, time.Local)
+		if _, candidateOffset := candidate.Zone(); candidateOffset != offset {
+			probe = candidate
+			break
+		}
+	}
+	if probe.IsZero() {
+		t.Skip("local time zone does not observe DST")
+	}
+	// e.g. "Jan 15 12:00:00 EDT 2026" while today's zone is EDT: the
+	// explicit zone must be honored even though that date is in EST
+	source := probe.Format("Jan 2 15:04:05") + " " + name + " " + probe.Format("2006")
+	correct := time.Date(probe.Year(), probe.Month(), probe.Day(), 12, 0, 0, 0, time.FixedZone(name, offset))
+	computed, err := Reformat(source, "%s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if computed != strconv.FormatInt(correct.Unix(), 10) {
+		t.Errorf("[computed: %v] != [correct: %v] for %q", computed, correct.Unix(), source)
 	}
 }
 
@@ -128,6 +275,26 @@ func TestParseDateTimePre1970(t *testing.T) {
 	}
 	if len(future) != 1 || !strings.Contains(future[0], "1969-12-31 17:00:00") {
 		t.Errorf("[computed: %v] does not contain: [correct: 1969-12-31 17:00:00]", future)
+	}
+}
+
+func TestRelativeDatesExactly24Hours(t *testing.T) {
+	// yesterday and tomorrow are exactly -/+ 24 hours of the current time,
+	// as documented, even across DST transitions (calendar-day arithmetic
+	// would be 23 or 25 real hours on the two transition days); the
+	// expansions come from separate Now() calls and the strings are
+	// second-granular, so allow a small tolerance
+	yesterday, err := parseDateTime(ConvertRelativeDateToActual("yesterday"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tomorrow, err := parseDateTime(ConvertRelativeDateToActual("tomorrow"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	span := tomorrow.Sub(yesterday)
+	if span < 48*time.Hour-2*time.Second || span > 48*time.Hour+2*time.Second {
+		t.Errorf("yesterday to tomorrow spans %v, expected 48h", span)
 	}
 }
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,35 @@ Use "dtmate --help-all" for duration syntax, brief units, and conversion notes.
 **Note:** The `-n` switch along with `-r` will emit a comma-delimited output
 * * Example: `dtmate dur now 1h -a -n -r 3`
 
+## Date and Duration Parsing Notes
+
+* **Slash dates** default to US order, month first: `01/02/2024` is January 2.
+* * Set `DTMATE_DATE_ORDER=DMY` for day/month/year, or `MDY` to silence the
+    ambiguity warning; a field greater than 12 (such as `25/12/2024`)
+    disambiguates on its own.
+* **Pure integers** parse by digit count: 10 digits are Unix seconds, 13 are
+  Unix milliseconds, while 4, 8, and 14 digits are a year (`2024`), a compact
+  date (`20240101`), and a compact date/time (`20240101080102`); 11, 12, and
+  other digit counts are ambiguous and rejected.
+* **Negative timestamps** are rejected everywhere; pre-1970 date/times are
+  fully supported through normal date strings such as `1950-01-01`.
+* **Relative dates**: `yesterday` and `tomorrow` are exactly 24 hours from
+  now, even across daylight saving transitions.
+* **Duration amounts** must be plain decimals (`90`, `1.5`, and mid-string
+  negatives such as `1 year -30 days` in `conv`); `NaN`, `Inf`, exponent
+  (`1e2`), and hex (`0x1p4`) forms are rejected.
+* **Duration range and precision**: durations are computed in integer
+  nanoseconds, so integral amounts are exact; fractional amounts carry
+  float64 precision (about 15-16 significant digits); totals are limited to
+  about +/-292 years.
+* **Brief sub-second targets**: a lone `us` or `ns` target means that
+  sub-second unit; a lone `ms` keeps its historical minutes+seconds meaning
+  and warns on stderr (use `.ms` or `milliseconds` for milliseconds);
+  combine larger and sub-second units with a dot, such as `ms.msusns`.
+* **Repeat and until**: `-r` is capped at 1,000,000 results, and `-u` must
+  lie in the direction of travel (after the start when adding, before it
+  when subtracting).
+
 ## Command Line Examples
 
 <details>
@@ -269,8 +298,14 @@ $ dtmate diff 2024-06-07T08:00:00Z 2024-06-07T08:05:05-05:00
 5 hours 5 minutes 5 seconds
 
 # same input, also convert duration to minutes and seconds
+# a bare "ms" target warns on stderr because ms means milliseconds elsewhere
 $ dtmate diff 2024-06-07T08:00:00Z 2024-06-07T08:05:05-05:00 -c ms
+warning: target "ms" is ambiguous: interpreting as minutes+seconds; use ".ms" or "milliseconds" for milliseconds
 305 minutes 5 seconds
+
+# a dot selects sub-second units: .ms is milliseconds, no warning
+$ dtmate diff 2024-06-07T08:00:00Z 2024-06-07T08:05:05-05:00 -c .ms
+18305000 milliseconds
 
 # convert to a single unit, showing 2 decimal places
 # without -d, this would truncate to just: 2 years
@@ -279,7 +314,7 @@ $ dtmate diff 2023-10-17 2026-07-04 -c Y -d 2
 
 # differentiate sub-second durations with a dot
 # note the "ms" on both sides of the dot: minutes & seconds vs milliseconds
-$ diff now "2020-01-01 11:12:13.123456789" -c ms.msusns
+$ dtmate diff now "2020-01-01 11:12:13.123456789" -c ms.msusns
 -2566445 minutes 40 seconds 876 milliseconds 542 microseconds 985 nanoseconds
 
 # using a format which includes spaces
@@ -458,6 +493,19 @@ $ dtmate fmt 1704085262 "%F %T"
 # also from milliseconds
 $ dtmate fmt 1704085262999 "%F %T"
 2024-01-01 00:01:02
+
+# compact integer date/times: 4, 8, or 14 digits
+$ dtmate fmt 20240101080102 "%F %T"
+2024-01-01 08:01:02
+
+# ambiguous slash dates default to month/day/year and warn on stderr
+$ dtmate fmt 01/02/2024 "%F"
+warning: "01/02/2024" is ambiguous: interpreting as month/day/year; set DTMATE_DATE_ORDER=DMY to override
+2024-01-02
+
+# pin the order with an environment variable
+$ DTMATE_DATE_ORDER=DMY dtmate fmt 01/02/2024 "%F"
+2024-02-01
 
 ########################### "dtmate tz" examples ###########################
 

--- a/cmd/dtmate/cmd/diff.go
+++ b/cmd/dtmate/cmd/diff.go
@@ -92,13 +92,16 @@ func outputDiff(start, end string, brief bool) {
 		os.Exit(1)
 	}
 	diff := DateTimeMate.NewDiff(DateTimeMate.DiffWithStart(start), DateTimeMate.DiffWithEnd(end), DateTimeMate.DiffWithBrief(brief), DateTimeMate.DiffWithAbsolute(optDiffAbsolute))
-	result, _, err := diff.CalculateDiff()
+	result, duration, err := diff.CalculateDiff()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	if optDiffConv != "" {
-		result = convDuration(result, optDiffConv, optDiffBrief, optDiffDecimals)
+		// convert from the exact duration, not the human-readable string:
+		// the formatted string truncates sub-unit remainders and durafmt
+		// uses 365-day years while conv uses 365.25
+		result = convDuration(fmt.Sprintf("%d nanoseconds", duration.Nanoseconds()), optDiffConv, optDiffBrief, optDiffDecimals)
 	}
 	if optRootNoNewline {
 		fmt.Print(result)

--- a/cmd/dtmate/cmd/root.go
+++ b/cmd/dtmate/cmd/root.go
@@ -25,9 +25,18 @@ RELATIVE DATE SHORTCUTS
   tomorrow         exactly 24 hours after now
   example: dtmate dur today 7h10m -a -u tomorrow
 
+DATE PARSING
+  slash dates default to US order: 01/02/2024 is January 2
+  set DTMATE_DATE_ORDER=DMY for day/month/year, or MDY to silence the warning
+  pure integers: 10 digits are unix seconds, 13 unix milliseconds;
+    4, 8, and 14 digits are a year, compact date, and compact date/time
+
 CONVERSION NOTES
   1 year equals 365.25 days
   months are not a unit; their lengths vary between 28 and 31 days
+  durations are limited to about +/-292 years
+  a lone ns or us target means that sub-second unit; a lone ms target
+    means minutes+seconds and warns (use .ms for milliseconds)
   separate sub-second brief target units with a dot:
     dtmate conv 4321s123456789ns hms.msusns
   use -d to round the smallest unit to N decimal places:

--- a/conv.go
+++ b/conv.go
@@ -1,37 +1,44 @@
 package DateTimeMate
 
 import (
+	"errors"
 	"fmt"
+	"math"
+	"os"
 	"strconv"
 	"strings"
 )
 
+// all duration math is carried out in integer nanoseconds so that integral
+// amounts convert exactly; a year is 365.25 days, which is a whole number
+// of nanoseconds, so even the fractional-day year stays exact
 const (
-	secondsPerNanoseconds = 0.000000001
-	secondsPerMicrosecond = 0.000001
-	secondsPerMillisecond = 0.001
-	secondsPerMinute      = 60
-	secondsPerHour        = 60 * secondsPerMinute
-	secondsPerDay         = 24 * secondsPerHour
-	secondsPerWeek        = 7 * secondsPerDay
-	secondsPerYear        = 365.25 * secondsPerDay
+	nanosPerMicrosecond int64 = 1_000
+	nanosPerMillisecond int64 = 1_000_000
+	nanosPerSecond      int64 = 1_000_000_000
+	nanosPerMinute            = 60 * nanosPerSecond
+	nanosPerHour              = 60 * nanosPerMinute
+	nanosPerDay               = 24 * nanosPerHour
+	nanosPerWeek              = 7 * nanosPerDay
+	nanosPerYear              = 31_557_600_000_000_000 // 365.25 * nanosPerDay
 )
 
-var unitMap = map[string]float64{
-	"nanosecond":  secondsPerNanoseconds,
-	"microsecond": secondsPerMicrosecond,
-	"millisecond": secondsPerMillisecond,
-	"second":      1,
-	"minute":      secondsPerMinute,
-	"hour":        secondsPerHour,
-	"day":         secondsPerDay,
-	"week":        secondsPerWeek,
-	"year":        secondsPerYear,
+var unitNanos = map[string]int64{
+	"nanosecond":  1,
+	"microsecond": nanosPerMicrosecond,
+	"millisecond": nanosPerMillisecond,
+	"second":      nanosPerSecond,
+	"minute":      nanosPerMinute,
+	"hour":        nanosPerHour,
+	"day":         nanosPerDay,
+	"week":        nanosPerWeek,
+	"year":        nanosPerYear,
 }
 
 var unitBriefMap = map[string]string{
 	"ns": "nanosecond",
 	"us": "microsecond",
+	"µs": "microsecond",
 	"ms": "millisecond",
 	"s":  "second",
 	"m":  "minute",
@@ -40,6 +47,12 @@ var unitBriefMap = map[string]string{
 	"W":  "week",
 	"Y":  "year",
 }
+
+// subSecondBriefUnits are the brief sub-second unit tokens accepted after
+// the dot in a combined target such as "hms.msusns"; "ns", "us", and "µs"
+// (but not "ms", which per-rune means minutes+seconds) are also accepted as
+// a whole pre-dot segment
+var subSecondBriefUnits = []string{"ms", "us", "µs", "ns"}
 
 type Conv struct {
 	Source   string
@@ -95,18 +108,67 @@ func normalizeUnit(unit string) string {
 	return removeTrailingS(strings.ToLower(unit))
 }
 
-// parseDurationSeconds converts a duration string to a total number of seconds.
+// isValidAmount reports whether s is a plain decimal amount matching
+// an optional leading "-", digits, and an optional fractional part; this
+// deliberately excludes the exponent ("1e2"), hex ("0x1p4"), "NaN", and
+// "Inf" forms that strconv.ParseFloat would otherwise accept
+func isValidAmount(s string) bool {
+	s = strings.TrimPrefix(s, "-")
+	whole, frac, hasDot := strings.Cut(s, ".")
+	if !isAllDigits(whole) {
+		return false
+	}
+	return !hasDot || isAllDigits(frac)
+}
+
+// errDurationRange is returned whenever a duration total or amount cannot
+// be represented in int64 nanoseconds
+var errDurationRange = errors.New("duration exceeds the supported range of about 292 years")
+
+// addInt64Checked adds two int64 values, erroring on overflow
+func addInt64Checked(a, b int64) (int64, error) {
+	sum := a + b
+	if (b > 0 && sum < a) || (b < 0 && sum > a) {
+		return 0, errDurationRange
+	}
+	return sum, nil
+}
+
+// amountToNanos converts one textual amount of a unit to nanoseconds:
+// integral amounts multiply exactly in int64, while fractional amounts fall
+// back to float64 and are rounded to the nearest nanosecond
+func amountToNanos(amount string, unitNs int64) (int64, error) {
+	if !isValidAmount(amount) {
+		return 0, fmt.Errorf("invalid amount: %q", amount)
+	}
+	if v, err := strconv.ParseInt(amount, 10, 64); err == nil {
+		if v != 0 && (v > math.MaxInt64/unitNs || v < math.MinInt64/unitNs) {
+			return 0, errDurationRange
+		}
+		return v * unitNs, nil
+	}
+	v, err := strconv.ParseFloat(amount, 64)
+	if err != nil {
+		return 0, err
+	}
+	ns := v * float64(unitNs)
+	if ns >= math.MaxInt64 || ns <= math.MinInt64 {
+		return 0, errDurationRange
+	}
+	return int64(math.Round(ns)), nil
+}
+
+// parseDurationNanos converts a duration string to a total number of
+// nanoseconds.
 //
 // The source may be in long form ("1 hour 30 minutes") or brief form ("1h30m");
 // brief input is first expanded to long form. Long form must contain alternating
-// numeric values and time unit strings, with units (defined in unitMap) accepted
-// in both singular and plural forms.
-//
-// Returns:
-//   - float64: The total time converted to seconds.
-//   - error: An error if parsing fails, typically due to invalid numeric input
-//     or an unknown unit.
-func parseDurationSeconds(source string) (float64, error) {
+// numeric values and time unit strings, with units (defined in unitNanos)
+// accepted in both singular and plural forms. Integral amounts convert
+// exactly; fractional amounts carry float64 precision (about 15-16
+// significant digits). The total must fit in int64 nanoseconds, about
+// +/-292 years.
+func parseDurationNanos(source string) (int64, error) {
 	if !isLongFormDuration(strings.Fields(source)) {
 		// brief format is being used so convert to long duration format
 		expandedSource, err := expandBriefSourceDuration(source)
@@ -116,24 +178,32 @@ func parseDurationSeconds(source string) (float64, error) {
 		source = expandedSource
 	}
 	parts := strings.Fields(source)
-	var totalSeconds float64
+	var total int64
 
 	for i := 0; i < len(parts); i += 2 {
-		value, err := strconv.ParseFloat(parts[i], 64)
-		if err != nil {
-			return 0, err
-		}
 		if i+1 >= len(parts) {
 			return 0, fmt.Errorf("missing unit after %q in: %s", parts[i], source)
 		}
 		unit := normalizeUnit(parts[i+1])
-		seconds, ok := unitMap[unit]
+		unitNs, ok := unitNanos[unit]
 		if !ok {
 			return 0, fmt.Errorf("unknown source unit: %q", parts[i+1])
 		}
-		totalSeconds += value * seconds
+		ns, err := amountToNanos(parts[i], unitNs)
+		if err != nil {
+			return 0, err
+		}
+		total, err = addInt64Checked(total, ns)
+		if err != nil {
+			return 0, err
+		}
 	}
-	return totalSeconds, nil
+	if total == math.MinInt64 {
+		// reject the one value whose negation overflows, so callers can
+		// always take the absolute value safely
+		return 0, errDurationRange
+	}
+	return total, nil
 }
 
 // resolveTargetUnits validates a target unit specification and expands it into
@@ -147,78 +217,156 @@ func resolveTargetUnits(target string) ([]string, error) {
 		return nil, fmt.Errorf("no target units specified")
 	}
 	if len(targetUnits) == 1 {
-		if _, ok := unitMap[normalizeUnit(target)]; !ok {
+		if _, ok := unitNanos[normalizeUnit(target)]; !ok {
 			// brief format is being used so convert to long duration format
 			var err error
 			targetUnits, err = expandBriefTargetDuration(target)
 			if nil != err {
 				return nil, err
 			}
+			if len(targetUnits) == 0 {
+				return nil, fmt.Errorf("no target units specified: %q", target)
+			}
 		}
 	}
 	for _, unit := range targetUnits {
-		if _, ok := unitMap[normalizeUnit(unit)]; !ok {
+		if _, ok := unitNanos[normalizeUnit(unit)]; !ok {
 			return nil, fmt.Errorf("unknown target unit: %q", unit)
 		}
 	}
 	return targetUnits, nil
 }
 
-// formatTarget converts a duration in seconds to a human-readable
+// roundDiv divides a non-negative a by a positive b, rounding half up
+func roundDiv(a, b int64) int64 {
+	half := b / 2
+	if a > math.MaxInt64-half {
+		// avoid overflow at the very top of the range; plain truncation
+		// only affects totals within half a quantum of 292 years
+		return a / b
+	}
+	return (a + half) / b
+}
+
+// formatTarget converts a duration in nanoseconds to a human-readable
 // string representation using the specified time units.
 //
 // Parameters:
-//   - seconds: The duration to format, expressed in seconds.
+//   - totalNs: The signed duration to format, expressed in nanoseconds.
 //   - units: A slice of strings representing the desired time units for the output.
-//     These should correspond to keys in the unitMap (e.g., "hour", "minute", "second").
+//     These should correspond to keys in unitNanos (e.g., "hour", "minute", "second").
 //
-// The function iterates through the provided units, converting the input seconds into
-// each unit as appropriate. It builds a string representation, including only non-zero
-// values. The function handles singular and plural forms of the units.
+// The function walks the units from largest to smallest with integer
+// division, including only non-zero values and handling singular and plural
+// forms. A negative duration is rendered with a single leading "-", which
+// is omitted when the formatted value itself is zero.
 //
-// When Conv.Decimals is greater than zero, the last (smallest) unit is formatted with
-// that many decimal places, rounded, and is always included even when less than one.
+// When Conv.Decimals is greater than zero, the last (smallest) unit is
+// formatted with that many decimal places and is always included even when
+// less than one; the total is rounded once, to the display precision of
+// that unit, before the breakdown so a rounding carry propagates into the
+// larger units (119.96 seconds becomes "2 minutes 0.0 seconds"). When the
+// units are not commensurate (a year is not a whole number of weeks or
+// days), the smaller units still absorb the remainder exactly as truncated
+// integer arithmetic dictates.
 //
 // Returns:
 //   - string: A formatted string representing the duration using the specified units.
 //     For example: "2 hours 30 minutes 45 seconds"
-func (conv *Conv) formatTarget(seconds float64, units []string) string {
+func (conv *Conv) formatTarget(totalNs int64, units []string) string {
+	negative := totalNs < 0
+	rem := totalNs
+	if negative {
+		rem = -rem
+	}
+
+	pow10 := int64(1)
+	for i := 0; i < conv.Decimals; i++ {
+		pow10 *= 10
+	}
+	// pre-round the total once, at the display granularity of the smallest
+	// unit, so a rounding carry propagates through the larger units
+	// (119.96 seconds -> "2 minutes 0.0 seconds"); this is only valid when
+	// every larger unit is a whole multiple of that granularity, otherwise
+	// (e.g. years over weeks) the pre-rounding would perturb the larger
+	// units and the last unit is rounded on its own instead
+	preRounded := false
+	lastNs := unitNanos[normalizeUnit(units[len(units)-1])]
+	if conv.Decimals > 0 && lastNs%pow10 == 0 {
+		quantum := lastNs / pow10
+		preRounded = true
+		for _, unit := range units[:len(units)-1] {
+			if unitNanos[normalizeUnit(unit)]%quantum != 0 {
+				preRounded = false
+				break
+			}
+		}
+		if preRounded && quantum > 1 {
+			if rounded := roundDiv(rem, quantum); rounded <= math.MaxInt64/quantum {
+				rem = rounded * quantum
+			}
+		}
+	}
+
 	result := ""
+	nonZero := false
 	for i, unit := range units {
 		unit = normalizeUnit(unit)
-		unitInSeconds := unitMap[unit]
-		value := seconds / unitInSeconds
+		unitNs := unitNanos[unit]
 
 		if conv.Decimals > 0 && i == len(units)-1 {
-			if value < 0 { // guard against float underflow producing "-0.00"
-				value = 0
+			whole := rem / unitNs
+			sub := rem % unitNs
+			var ticks int64
+			switch {
+			case preRounded:
+				ticks = sub / (unitNs / pow10)
+			case unitNs%pow10 == 0:
+				ticks = roundDiv(sub, unitNs/pow10)
+			default:
+				// the requested precision is finer than a nanosecond, so
+				// scale up instead; the operands are small enough that the
+				// product cannot overflow
+				ticks = roundDiv(sub*pow10, unitNs)
 			}
-			formatted := strconv.FormatFloat(value, 'f', conv.Decimals, 64)
-			if rounded, _ := strconv.ParseFloat(formatted, 64); rounded != 1 {
+			if ticks == pow10 {
+				// the last unit rounded up to a whole value; carry one level
+				whole++
+				ticks = 0
+			}
+			if whole != 0 || ticks != 0 {
+				nonZero = true
+			}
+			if whole != 1 || ticks != 0 {
 				unit += "s"
 			}
-			result += fmt.Sprintf("%s %s ", formatted, unit)
+			result += fmt.Sprintf("%d.%0*d %s ", whole, conv.Decimals, ticks, unit)
 			continue
 		}
 
-		intValue := int(value)
-		if intValue <= 0 {
+		value := rem / unitNs
+		if value == 0 {
 			continue
 		}
+		nonZero = true
 
-		if intValue > 1 {
+		if value > 1 {
 			unit += "s"
 		}
 
-		result += fmt.Sprintf("%d %s ", intValue, unit)
-		seconds -= float64(intValue) * unitInSeconds
+		result += fmt.Sprintf("%d %s ", value, unit)
+		rem -= value * unitNs
 	}
 	if result == "" {
 		// every unit truncated to zero, so emit zero of the smallest unit
 		// instead of an empty string
 		result = fmt.Sprintf("0 %ss", normalizeUnit(units[len(units)-1]))
 	}
-	return strings.TrimSpace(result)
+	result = strings.TrimSpace(result)
+	if negative && nonZero {
+		result = "-" + result
+	}
+	return result
 }
 
 // isLongFormDuration reports whether the fields form alternating
@@ -255,35 +403,46 @@ func expandBriefSourceDuration(period string) (string, error) {
 
 // expandBriefTargetDuration give a brief duration, convert to long format
 // example: WDhms.msusns => "week day hour minute second millisecond microsecond nanosecond"
+// before the dot each rune is a unit, so "ms" is minutes+seconds there; a
+// bare "ms" target keeps that meaning for backward compatibility but warns
+// on stderr, because "ms" means milliseconds everywhere else. A pre-dot
+// segment that is exactly "ns", "us", or "µs" means that sub-second unit
+// (per-rune those were never valid). A dot must be followed by sub-second
+// units.
 func expandBriefTargetDuration(period string) ([]string, error) {
-	usingSubSeconds := false
+	pre, post, hasDot := strings.Cut(period, ".")
 	var result []string
-	var i int
-	var ch rune
-	for i, ch = range period {
-		if ch == '.' {
-			usingSubSeconds = true
-			break
-		}
-		longName, ok := unitBriefMap[string(ch)]
-		if !ok {
-			return nil, fmt.Errorf("[expandBriefTargetDuration] Invalid time duration: %c", ch)
-		}
+	if longName, ok := unitBriefMap[pre]; ok && len(pre) > 1 && pre != "ms" {
 		result = append(result, longName)
-	}
-	if usingSubSeconds {
-		i++
-		period := period[i:] // move past the dot
-		if len(period)%2 != 0 {
-			return nil, fmt.Errorf("[expandBriefTargetDuration] Invalid sub-second duration: %s", period)
+	} else {
+		if period == "ms" {
+			fmt.Fprintf(os.Stderr, "warning: target \"ms\" is ambiguous: interpreting as minutes+seconds; use \".ms\" or \"milliseconds\" for milliseconds\n")
 		}
-		for j := 0; j < len(period); j += 2 {
-			subSecPeriod := period[j : j+2]
-			longName, ok := unitBriefMap[subSecPeriod]
+		for _, ch := range pre {
+			longName, ok := unitBriefMap[string(ch)]
 			if !ok {
-				return nil, fmt.Errorf("[expandBriefTargetDuration] Invalid duration: %c", ch)
+				return nil, fmt.Errorf("[expandBriefTargetDuration] invalid unit %q in target %q; valid units are Y W D h m s, with sub-second units after a dot, such as \"hms.msusns\"", string(ch), period)
 			}
 			result = append(result, longName)
+		}
+	}
+	if hasDot {
+		if post == "" {
+			return nil, fmt.Errorf("[expandBriefTargetDuration] missing sub-second units after the dot in target %q", period)
+		}
+		for post != "" {
+			matched := false
+			for _, brief := range subSecondBriefUnits {
+				if strings.HasPrefix(post, brief) {
+					result = append(result, unitBriefMap[brief])
+					post = post[len(brief):]
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return nil, fmt.Errorf("[expandBriefTargetDuration] invalid sub-second unit %q in target %q", post, period)
+			}
 		}
 	}
 	return result, nil
@@ -294,13 +453,15 @@ func expandBriefTargetDuration(period string) ([]string, error) {
 //
 // This function performs the following steps:
 // 1. If the Source is in brief format (e.g., "1h30m"), it expands it to long format.
-// 2. Parses the Source string to calculate the total duration in seconds.
+// 2. Parses the Source string to calculate the total duration in nanoseconds.
 // 3. If the Target is in brief format, it expands it to a list of unit names.
-// 4. Formats the duration in seconds according to the specified target units.
+// 4. Formats the duration according to the specified target units.
 // 5. If Conv.Brief is true, it converts the result back to brief format.
 //
 // The function handles both brief (e.g., "1h30m") and long (e.g., "1 hour 30 minutes") formats
-// for both input and output.
+// for both input and output. A leading "-" negates the whole source, and a
+// net-negative total (e.g. "30 minutes -2 hours") is rendered with a
+// leading "-".
 //
 // Returns:
 //   - string: The converted duration in the specified target format.
@@ -315,21 +476,20 @@ func (conv *Conv) ConvertDuration() (string, error) {
 		source = s
 		isNegativeDuration = true
 	}
-	seconds, err := parseDurationSeconds(source)
+	total, err := parseDurationNanos(source)
 	if err != nil {
 		return "", err
+	}
+	if isNegativeDuration {
+		total = -total
 	}
 	targetUnits, err := resolveTargetUnits(conv.Target)
 	if err != nil {
 		return "", err
 	}
-	result := conv.formatTarget(seconds, targetUnits)
+	result := conv.formatTarget(total, targetUnits)
 	if conv.Brief {
 		result = shrinkPeriod(result)
 	}
-	result = strings.TrimSpace(result)
-	if isNegativeDuration {
-		result = "-" + result
-	}
-	return result, nil
+	return strings.TrimSpace(result), nil
 }

--- a/conv_test.go
+++ b/conv_test.go
@@ -1,6 +1,9 @@
 package DateTimeMate
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func testConv(t *testing.T, source, target string, brief bool, correct string) {
 	t.Helper()
@@ -116,9 +119,9 @@ func TestConvInvalidInput(t *testing.T) {
 
 func TestConvEmptyTarget(t *testing.T) {
 	t.Parallel()
-	// an empty or whitespace-only target used to panic with an
+	// an empty, whitespace-only, or bare-dot target used to panic with an
 	// index-out-of-range error instead of returning an error
-	for _, target := range []string{"", "   "} {
+	for _, target := range []string{"", "   ", "."} {
 		conv := NewConv(ConvWithSource("90 minutes"), ConvWithTarget(target))
 		if _, err := conv.ConvertDuration(); err == nil {
 			t.Errorf("expected an error for empty target %q, got nil", target)
@@ -140,6 +143,104 @@ func TestConvMixedSignSource(t *testing.T) {
 	t.Parallel()
 	// a negative amount mid-string subtracts from the total
 	testConv(t, "1 year -30 days", "days", false, "335 days")
+}
+
+func TestConvNetNegative(t *testing.T) {
+	t.Parallel()
+	// a net-negative total renders with a leading "-" instead of
+	// silently collapsing to zero
+	testConv(t, "30 minutes -2 hours", "minutes", false, "-90 minutes")
+	testConv(t, "30 minutes -2 hours", "minutes", true, "-90m")
+	testConvDecimals(t, "30 minutes -2 hours", "hours", false, 2, "-1.50 hours")
+}
+
+func TestConvDecimalsCarry(t *testing.T) {
+	t.Parallel()
+	// rounding the smallest unit must carry into the larger units
+	// instead of printing a full-unit value such as "60.0 seconds"
+	testConvDecimals(t, "119.96 seconds", "minutes seconds", false, 1, "2 minutes 0.0 seconds")
+	testConvDecimals(t, "59.996 seconds", "minutes seconds", false, 2, "1 minute 0.00 seconds")
+	// no carry when the rounded value stays below the unit boundary
+	testConvDecimals(t, "119.94 seconds", "minutes seconds", false, 1, "1 minute 59.9 seconds")
+}
+
+func TestConvExactSubSecond(t *testing.T) {
+	t.Parallel()
+	// float-imprecise amounts must round to the nearest nanosecond, never
+	// truncate a whole unit away
+	testConv(t, "0.7 seconds", ".ms", false, "700 milliseconds")
+	testConv(t, "1µs", ".ns", false, "1000 nanoseconds")
+	testConv(t, "0.3 seconds -0.1 seconds", ".msusns", false, "200 milliseconds")
+	testConv(t, "0.7 hours", "minutes seconds", false, "42 minutes")
+}
+
+func TestConvRejectsNonFiniteAmounts(t *testing.T) {
+	t.Parallel()
+	// amounts are restricted to plain decimals: NaN, Inf, exponent, and
+	// hex float forms accepted by strconv.ParseFloat must all error
+	for _, source := range []string{"NaN seconds", "Inf seconds", "-Inf seconds", "1e2 seconds", "0x1p4 seconds", "+5 seconds"} {
+		conv := NewConv(ConvWithSource(source), ConvWithTarget("hours"))
+		if _, err := conv.ConvertDuration(); err == nil {
+			t.Errorf("Conv: expected an error for source %q, got nil", source)
+		}
+		dm := NewDurMath(DurMathWithFirst(source), DurMathWithSecond("1 hour"))
+		if _, err := dm.Add(); err == nil {
+			t.Errorf("DurMath: expected an error for first %q, got nil", source)
+		}
+	}
+}
+
+func TestConvBriefSubSecondTargets(t *testing.T) {
+	t.Parallel()
+	// a bare "ms" target keeps its historical minutes+seconds meaning for
+	// backward compatibility (with a stderr warning); "ns"/"us"/"µs" were
+	// never valid per-rune, so as whole tokens they mean that sub-second unit
+	testConv(t, "1h", "ms", false, "60 minutes")
+	testConv(t, "61 seconds", "ms", false, "1 minute 1 second")
+	testConv(t, "1 second", "ns", false, "1000000000 nanoseconds")
+	testConv(t, "1 second", "us", false, "1000000 microseconds")
+	testConv(t, "1 second", "µs", false, "1000000 microseconds")
+	testConv(t, "1 second", ".µs", false, "1000000 microseconds")
+	// pre-dot "ms" is per-rune minutes+seconds, as originally documented
+	testConv(t, "62s1ms1us1ns", "ms.msusns", false, "1 minute 2 seconds 1 millisecond 1 microsecond 1 nanosecond")
+	// combined targets are unchanged
+	testConv(t, "694861.001001001 seconds", "WDhms.msusns", false, "1 week 1 day 1 hour 1 minute 1 second 1 millisecond 1 microsecond 1 nanosecond")
+
+	// error cases: unknown pre-dot rune, unknown sub-second token, and a
+	// dangling dot must all name the offending part
+	cases := []struct{ target, contains string }{
+		{"h.zz", `"zz"`},
+		{"h.", "missing sub-second units"},
+		{"x", `"x"`},
+		{"h.mszz", `"zz"`},
+	}
+	for _, c := range cases {
+		conv := NewConv(ConvWithSource("90 minutes"), ConvWithTarget(c.target))
+		_, err := conv.ConvertDuration()
+		if err == nil {
+			t.Errorf("expected an error for target %q, got nil", c.target)
+		} else if !strings.Contains(err.Error(), c.contains) {
+			t.Errorf("error for target %q should contain %s, got: %v", c.target, c.contains, err)
+		}
+	}
+}
+
+func TestConvRangeLimit(t *testing.T) {
+	t.Parallel()
+	// large integral nanosecond amounts convert exactly (no float64 detour)
+	testConv(t, "1234567890987654321 nanoseconds", "nanoseconds", false, "1234567890987654321 nanoseconds")
+	// the diff -c path feeds "<n> nanoseconds" through Conv; a 365-day span
+	// must come out as exactly 8760 hours
+	testConv(t, "31536000000000000 nanoseconds", "hours", false, "8760 hours")
+	// totals beyond int64 nanoseconds (about +/-292 years) error
+	for _, source := range []string{"1000 years", "9223372036854775808 nanoseconds", "300 years 300 years"} {
+		conv := NewConv(ConvWithSource(source), ConvWithTarget("hours"))
+		if _, err := conv.ConvertDuration(); err == nil {
+			t.Errorf("expected a range error for source %q, got nil", source)
+		}
+	}
+	// just inside the range still works
+	testConv(t, "292 years", "years", false, "292 years")
 }
 
 func TestConvZeroResult(t *testing.T) {
@@ -262,19 +363,19 @@ func TestConvMsUsNs(t *testing.T) {
 	t.Parallel()
 	source := "4321s123456789ns"
 	target := "hms.msusns"
-	correct := "1 hour 12 minutes 1 second 123 milliseconds 456 microseconds 788 nanoseconds"
+	correct := "1 hour 12 minutes 1 second 123 milliseconds 456 microseconds 789 nanoseconds"
 	testConv(t, source, target, false, correct)
 
 	source = "-4321s123456789ns"
-	correct = "-1 hour 12 minutes 1 second 123 milliseconds 456 microseconds 788 nanoseconds"
+	correct = "-1 hour 12 minutes 1 second 123 milliseconds 456 microseconds 789 nanoseconds"
 	testConv(t, source, target, false, correct)
 
 	source = "4321s123456789ns"
-	correct = "1h12m1s123ms456us788ns"
+	correct = "1h12m1s123ms456us789ns"
 	testConv(t, source, target, true, correct)
 
 	source = "-4321s123456789ns"
-	correct = "-1h12m1s123ms456us788ns"
+	correct = "-1h12m1s123ms456us789ns"
 	testConv(t, source, target, true, correct)
 
 	source = "4321s001001001ns"
@@ -298,19 +399,19 @@ func TestConvNanoseconds1(t *testing.T) {
 	t.Parallel()
 	source := "1234567890987654321ns"
 	target := "YWDhms.msusns"
-	correct := "39 years 6 weeks 2 days 5 hours 31 minutes 30 seconds 987 milliseconds 654 microseconds 447 nanoseconds"
+	correct := "39 years 6 weeks 2 days 5 hours 31 minutes 30 seconds 987 milliseconds 654 microseconds 321 nanoseconds"
 	testConv(t, source, target, false, correct)
 
 	source = "-1234567890987654321ns"
-	correct = "-39 years 6 weeks 2 days 5 hours 31 minutes 30 seconds 987 milliseconds 654 microseconds 447 nanoseconds"
+	correct = "-39 years 6 weeks 2 days 5 hours 31 minutes 30 seconds 987 milliseconds 654 microseconds 321 nanoseconds"
 	testConv(t, source, target, false, correct)
 
 	source = "1234567890987654321ns"
-	correct = "39Y6W2D5h31m30s987ms654us447ns"
+	correct = "39Y6W2D5h31m30s987ms654us321ns"
 	testConv(t, source, target, true, correct)
 
 	source = "-1234567890987654321ns"
-	correct = "-39Y6W2D5h31m30s987ms654us447ns"
+	correct = "-39Y6W2D5h31m30s987ms654us321ns"
 	testConv(t, source, target, true, correct)
 }
 

--- a/diff.go
+++ b/diff.go
@@ -2,7 +2,6 @@ package DateTimeMate
 
 import (
 	"fmt"
-	"github.com/golang-module/carbon/v2"
 	"github.com/hako/durafmt"
 	"time"
 )
@@ -54,44 +53,58 @@ func (diff *Diff) String() string {
 	return fmt.Sprintf("Start:%v End:%v Brief:%v Absolute:%v", diff.Start, diff.End, diff.Brief, diff.Absolute)
 }
 
-// parseDiffTime parses one side of a diff: 10-digit (seconds) and 13-digit
-// (milliseconds) integers are treated as Unix timestamps; anything else is
-// parsed with carbon first, falling back to parsetime if carbon fails
-func parseDiffTime(source string) (time.Time, error) {
-	if isUnixTimestamp(source) {
-		return unixStringToTime(source)
-	}
-	converted := ConvertRelativeDateToActual(source)
-	if c := carbon.Parse(converted); c.Error == nil {
-		return c.StdTime(), nil
-	}
-	return parseDateTime(converted)
-}
-
-// CalculateDiff return the time difference and also set dt.Diff
-// first try to parse with carbon, fallback to parsing with parsetime if carbon fails to parse
+// CalculateDiff returns the time difference between Start and End, both as
+// a formatted string and as a time.Duration; both sides are parsed with the
+// same shared chain used by every other sub-command (parseDateTimeOrUnix)
 // when Absolute is set, both the formatted string and the returned duration are non-negative
 func (diff *Diff) CalculateDiff() (string, time.Duration, error) {
-	start, err := parseDiffTime(diff.Start)
+	start, err := parseDateTimeOrUnix(diff.Start)
 	if err != nil {
 		return "", 0, err
 	}
-	end, err := parseDiffTime(diff.End)
+	end, err := parseDateTimeOrUnix(diff.End)
 	if err != nil {
 		return "", 0, err
-	}
-
-	yearDiff := end.Year() - start.Year()
-	if yearDiff > 291 || yearDiff < -291 {
-		return "", 0, fmt.Errorf("year difference of %d exceeds 291 year maximum", yearDiff)
 	}
 
 	duration := end.Sub(start)
+	// time.Time.Sub silently clamps a difference that overflows
+	// time.Duration, so detect saturation by checking the round trip; this
+	// accepts every representable span (about +/-292 years) instead of
+	// rejecting by calendar-year count
+	if !start.Add(duration).Equal(end) {
+		return "", 0, fmt.Errorf("difference between %q and %q exceeds the representable range of about 292 years", diff.Start, diff.End)
+	}
 	if diff.Absolute {
 		duration = duration.Abs()
 	}
 	parsed := durafmt.Parse(duration)
 	difference := fmt.Sprintf("%v", parsed)
+	// durafmt's smallest unit is the microsecond, so append any
+	// sub-microsecond remainder: a 1500ns diff renders as
+	// "1 microsecond 500 nanoseconds" and a sub-microsecond diff is a
+	// nanosecond count instead of an empty string
+	if rem := duration % time.Microsecond; rem != 0 {
+		ns := rem.Nanoseconds()
+		if ns < 0 {
+			ns = -ns
+		}
+		unit := "nanoseconds"
+		if ns == 1 {
+			unit = "nanosecond"
+		}
+		nsPart := fmt.Sprintf("%d %s", ns, unit)
+		// durafmt renders a sub-microsecond duration as "" ("-" when
+		// negative), so the nanosecond count becomes the whole output
+		if difference == "" || difference == "-" {
+			if duration < 0 {
+				nsPart = "-" + nsPart
+			}
+			difference = nsPart
+		} else {
+			difference += " " + nsPart
+		}
+	}
 	if diff.Brief {
 		difference = shrinkPeriod(difference)
 	}

--- a/diff_test.go
+++ b/diff_test.go
@@ -48,6 +48,21 @@ func TestDiffSignedResult(t *testing.T) {
 	testDiffAbsolute(t, "15:30:45", "12:00:00", true, false, "-3h30m45s", true)
 }
 
+func TestDiffSubMicrosecond(t *testing.T) {
+	t.Parallel()
+	// durafmt drops sub-microsecond remainders, so they are appended as
+	// nanoseconds; a sub-microsecond diff used to render as an empty string
+	testDiffStartEnd(t, "2024-06-07T08:00:00Z", "2024-06-07T08:00:00.0000005Z", false, "500 nanoseconds")
+	testDiffStartEnd(t, "2024-06-07T08:00:00Z", "2024-06-07T08:00:00.0000015Z", false, "1 microsecond 500 nanoseconds")
+	testDiffStartEnd(t, "2024-06-07T08:00:00Z", "2024-06-07T08:00:00.0000015Z", true, "1us500ns")
+	testDiffStartEnd(t, "2024-06-07T08:00:00Z", "2024-06-07T08:00:00.000000001Z", false, "1 nanosecond")
+	// negative sub-microsecond diffs carry the sign on the leading term
+	testDiffAbsolute(t, "2024-06-07T08:00:00.0000005Z", "2024-06-07T08:00:00Z", false, false, "-500 nanoseconds", true)
+	// whole-microsecond and zero diffs are unchanged
+	testDiffStartEnd(t, "2024-06-07T08:00:00Z", "2024-06-07T08:00:00.000002Z", false, "2 microseconds")
+	testDiffStartEnd(t, "2024-06-07T08:00:00Z", "2024-06-07T08:00:00Z", false, "0 seconds")
+}
+
 func TestDiffAbsoluteResult(t *testing.T) {
 	t.Parallel()
 	// Absolute makes both the formatted string and the returned duration positive
@@ -156,6 +171,19 @@ func TestDiffYearOverflow(t *testing.T) {
 	_, _, err := diff.CalculateDiff()
 	if err == nil {
 		t.Error("expected error for year difference exceeding 291 years")
+	}
+
+	// a span inside time.Duration's range is representable even when the
+	// calendar years differ by more than 291 (the old guard rejected this)
+	diff = NewDiff(
+		DiffWithStart("2000-12-31"),
+		DiffWithEnd("2292-01-01"))
+	_, duration, err := diff.CalculateDiff()
+	if err != nil {
+		t.Errorf("expected a ~291-year span to be accepted, got: %v", err)
+	}
+	if duration <= 0 {
+		t.Errorf("expected a positive duration, got: %v", duration)
 	}
 }
 

--- a/dur.go
+++ b/dur.go
@@ -34,7 +34,8 @@ const (
 	expanded string = `(?:^|\s)(\d+(?:\.\d+)?)\s(years?|weeks?|days?|hours?|minutes?|seconds?|milliseconds?|microseconds?|nanoseconds?)`
 	hintMsg  string = "Hint: duplicate durations not allowed; dates in uppercase; times in lowercase"
 
-	// maxUntilIterations is a backstop against unbounded output from the until option
+	// maxUntilIterations is a backstop against unbounded output from the
+	// until and repeat options
 	maxUntilIterations = 1_000_000
 )
 
@@ -122,6 +123,9 @@ func (dur *Dur) addOrSub(op int) ([]string, error) {
 	if dur.Repeat < 0 {
 		return nil, fmt.Errorf("repeat must not be negative: %d", dur.Repeat)
 	}
+	if dur.Repeat > maxUntilIterations {
+		return nil, fmt.Errorf("repeat must not exceed %d results: %d", maxUntilIterations, dur.Repeat)
+	}
 	if dur.Repeat > 0 && dur.Until != "" {
 		return nil, fmt.Errorf("repeat & until are mutually exclusive")
 	}
@@ -160,6 +164,14 @@ func (dur *Dur) addOrSub(op int) ([]string, error) {
 		u, err := parseDateTimeOrUnix(dur.Until)
 		if err != nil {
 			return nil, err
+		}
+		// the until date/time must lie in the direction of travel, otherwise
+		// the loop would exit immediately with an empty result and no error
+		if opAdd == op && !u.After(f) {
+			return nil, fmt.Errorf("until date/time %q is not after from %q", dur.Until, dur.From)
+		}
+		if opSub == op && !u.Before(f) {
+			return nil, fmt.Errorf("until date/time %q is not before from %q", dur.Until, dur.From)
 		}
 		to := from
 		for i := 0; ; i++ {
@@ -210,8 +222,11 @@ func (dur *Dur) renderResults(all []carbon.Carbon) ([]string, error) {
 }
 
 // parsePeriod parses a period in either long or brief format into
-// (amount, unit) pairs, erroring if any part of the period is not understood
+// (amount, unit) pairs, erroring if any part of the period is not
+// understood; error messages quote the caller's original input, never the
+// internal brief-to-long expansion
 func parsePeriod(period string) ([][2]string, error) {
+	original := period
 	indexes := expandedRegexp.FindAllStringSubmatchIndex(period, -1)
 	if len(indexes) == 0 {
 		// brief format is being used so first expand it to the long format
@@ -222,7 +237,7 @@ func parsePeriod(period string) ([][2]string, error) {
 		}
 		indexes = expandedRegexp.FindAllStringSubmatchIndex(period, -1)
 		if len(indexes) == 0 {
-			return nil, fmt.Errorf("[parsePeriod] Invalid duration: %s", period)
+			return nil, fmt.Errorf("[parsePeriod] Invalid duration: %s", original)
 		}
 	}
 
@@ -238,7 +253,7 @@ func parsePeriod(period string) ([][2]string, error) {
 	}
 	leftover.WriteString(period[prev:])
 	if remains := strings.TrimSpace(leftover.String()); remains != "" {
-		return nil, fmt.Errorf("[parsePeriod] Invalid duration %q in: %s. %s", remains, period, hintMsg)
+		return nil, fmt.Errorf("[parsePeriod] Invalid duration %q in: %s. %s", remains, original, hintMsg)
 	}
 	return matches, nil
 }
@@ -274,34 +289,43 @@ func applyPeriod(to carbon.Carbon, periodMatches [][2]string, index int) (carbon
 // only allow one replacement per each period
 // Ex: 1h2m3s => 1 hour 2 minutes 3 seconds
 func expandPeriod(period string) (string, error) {
+	// the intermediate placeholders are control characters, which cannot
+	// appear in legitimate input; reject them up front so they can never
+	// be smuggled in as unit names
+	for _, ch := range period {
+		if ch < 0x20 && ch != '\t' {
+			return "", fmt.Errorf("[expandPeriod] Invalid period: %s. %s", period, hintMsg)
+		}
+	}
+
 	// a direct string replace will not work because some
 	// periods have overlapping strings, such as 's' with 'ms, 'us', 'ns'
 	// therefore convert each period to a unique string first
 	s := period
-	s = strings.Replace(s, "ns", "α", 1)
-	s = strings.Replace(s, "us", "β", 1)
-	s = strings.Replace(s, "µs", "β", 1)
-	s = strings.Replace(s, "ms", "γ", 1)
-	s = strings.Replace(s, "s", "δ", 1)
-	s = strings.Replace(s, "m", "ε", 1)
-	s = strings.Replace(s, "h", "ζ", 1)
-	s = strings.Replace(s, "D", "η", 1)
-	s = strings.Replace(s, "W", "θ", 1)
+	s = strings.Replace(s, "ns", "\x01", 1)
+	s = strings.Replace(s, "us", "\x02", 1)
+	s = strings.Replace(s, "µs", "\x02", 1)
+	s = strings.Replace(s, "ms", "\x03", 1)
+	s = strings.Replace(s, "s", "\x04", 1)
+	s = strings.Replace(s, "m", "\x05", 1)
+	s = strings.Replace(s, "h", "\x06", 1)
+	s = strings.Replace(s, "D", "\x07", 1)
+	s = strings.Replace(s, "W", "\x08", 1)
 	// Month (M) not supported
-	s = strings.Replace(s, "Y", "λ", 1)
+	s = strings.Replace(s, "Y", "\x0b", 1)
 
 	// now convert from the unique string back to the corresponding duration
 	p := s
-	p = strings.Replace(p, "α", " nanoseconds ", 1)
-	p = strings.Replace(p, "β", " microseconds ", 1)
-	p = strings.Replace(p, "γ", " milliseconds ", 1)
-	p = strings.Replace(p, "δ", " seconds ", 1)
-	p = strings.Replace(p, "ε", " minutes ", 1)
-	p = strings.Replace(p, "ζ", " hours ", 1)
-	p = strings.Replace(p, "η", " days ", 1)
-	p = strings.Replace(p, "θ", " weeks ", 1)
+	p = strings.Replace(p, "\x01", " nanoseconds ", 1)
+	p = strings.Replace(p, "\x02", " microseconds ", 1)
+	p = strings.Replace(p, "\x03", " milliseconds ", 1)
+	p = strings.Replace(p, "\x04", " seconds ", 1)
+	p = strings.Replace(p, "\x05", " minutes ", 1)
+	p = strings.Replace(p, "\x06", " hours ", 1)
+	p = strings.Replace(p, "\x07", " days ", 1)
+	p = strings.Replace(p, "\x08", " weeks ", 1)
 	// Month (M) not supported
-	p = strings.Replace(p, "λ", " years ", 1)
+	p = strings.Replace(p, "\x0b", " years ", 1)
 
 	// ensure each time & period was successfully replaced
 	// len of Fields should always be even because is part

--- a/dur_test.go
+++ b/dur_test.go
@@ -195,6 +195,61 @@ func TestDurNegativeRepeat(t *testing.T) {
 	}
 }
 
+func TestDurRepeatCap(t *testing.T) {
+	t.Parallel()
+	// repeat is capped like until, so a huge repeat errors immediately
+	// instead of allocating one result per iteration
+	dur := NewDur(DurWithFrom("2024-01-01"), DurWithDur("1 second"), DurWithRepeat(1_000_001))
+	if _, err := dur.Add(); err == nil {
+		t.Error("expected an error for a repeat above the cap, got nil")
+	}
+}
+
+func TestDurUntilWrongSide(t *testing.T) {
+	t.Parallel()
+	// an until date/time opposite the direction of travel errors instead
+	// of returning an empty result with a nil error
+	dur := NewDur(DurWithFrom("2024-06-01"), DurWithDur("1 day"), DurWithUntil("2024-01-01"))
+	if _, err := dur.Add(); err == nil {
+		t.Error("Add: expected an error for an until before from, got nil")
+	}
+	dur = NewDur(DurWithFrom("2024-01-01"), DurWithDur("1 day"), DurWithUntil("2024-06-01"))
+	if _, err := dur.Sub(); err == nil {
+		t.Error("Sub: expected an error for an until after from, got nil")
+	}
+	// until equal to from is also an error: no result can be produced
+	dur = NewDur(DurWithFrom("2024-01-01"), DurWithDur("1 day"), DurWithUntil("2024-01-01"))
+	if _, err := dur.Add(); err == nil {
+		t.Error("Add: expected an error for an until equal to from, got nil")
+	}
+}
+
+func TestDurPlaceholderUnits(t *testing.T) {
+	t.Parallel()
+	// the brief-expansion placeholders must never be accepted as units:
+	// "1α" used to add one nanosecond and "2λ" two years
+	for _, period := range []string{"1α", "2λ", "1\x01", "2\x0b"} {
+		dur := NewDur(DurWithFrom("2024-01-01 00:00:00"), DurWithDur(period))
+		if _, err := dur.Add(); err == nil {
+			t.Errorf("expected an error for period %q, got nil", period)
+		}
+	}
+}
+
+func TestDurPeriodErrorQuotesInput(t *testing.T) {
+	t.Parallel()
+	// error messages quote the original input, not the internal
+	// brief-to-long expansion with its doubled spaces
+	dur := NewDur(DurWithFrom("2024-01-01"), DurWithDur("2 h"))
+	_, err := dur.Add()
+	if err == nil {
+		t.Fatal("expected an error for period \"2 h\", got nil")
+	}
+	if !strings.Contains(err.Error(), "2 h") || strings.Contains(err.Error(), "hours") {
+		t.Errorf("error should quote the original input, got: %v", err)
+	}
+}
+
 func TestDurZeroPeriodUntil(t *testing.T) {
 	t.Parallel()
 	// a period that does not advance must error instead of looping forever

--- a/durmath.go
+++ b/durmath.go
@@ -128,9 +128,9 @@ func checkNegativeDuration(source string) error {
 	return nil
 }
 
-// compute parses both operands, adds or subtracts them, and formats the
-// signed result; the absolute value is formatted and a leading "-" is
-// prepended when the result is negative
+// compute parses both operands into integer nanoseconds, adds or subtracts
+// them, and formats the signed result; a negative result is rendered with
+// a leading "-" unless Absolute is set
 func (dm *DurMath) compute(subtract bool) (string, error) {
 	if dm.Decimals < 0 || dm.Decimals > 9 {
 		return "", fmt.Errorf("decimals must be between 0 and 9: %d", dm.Decimals)
@@ -141,26 +141,29 @@ func (dm *DurMath) compute(subtract bool) (string, error) {
 	if err := checkNegativeDuration(dm.Second); err != nil {
 		return "", err
 	}
-	first, err := parseDurationSeconds(dm.First)
+	first, err := parseDurationNanos(dm.First)
 	if err != nil {
 		return "", fmt.Errorf("first duration: %w", err)
 	}
-	second, err := parseDurationSeconds(dm.Second)
+	second, err := parseDurationNanos(dm.Second)
 	if err != nil {
 		return "", fmt.Errorf("second duration: %w", err)
 	}
 
-	result := first + second
 	if subtract {
-		result = first - second
+		second = -second
 	}
-	abs := math.Abs(result)
-	if math.Round(abs*1e9) == 0 {
-		// snap float noise below half a nanosecond to exactly zero so a
-		// zero result renders as "0 seconds", never "-0 seconds"
-		result, abs = 0, 0
+	result, err := addInt64Checked(first, second)
+	if err != nil {
+		return "", err
 	}
-	negative := result < 0
+	if result == math.MinInt64 {
+		// the one value whose negation overflows
+		return "", errDurationRange
+	}
+	if dm.Absolute && result < 0 {
+		result = -result
+	}
 
 	units := durMathDefaultUnits
 	if dm.Target != "" {
@@ -168,24 +171,16 @@ func (dm *DurMath) compute(subtract bool) (string, error) {
 		if err != nil {
 			return "", err
 		}
-	} else {
-		// extend with sub-second units only when a sub-second remainder
-		// survives rounding to whole nanoseconds, so binary float residue
-		// does not trigger a bogus extension
-		frac := abs - math.Floor(abs)
-		if r := math.Round(frac * 1e9); r >= 1 && r < 1e9 {
-			units = durMathAllUnits
-		}
+	} else if result%nanosPerSecond != 0 {
+		// extend with sub-second units only when the result carries a
+		// sub-second remainder
+		units = durMathAllUnits
 	}
 
 	formatter := &Conv{Decimals: dm.Decimals}
-	out := formatter.formatTarget(abs, units)
+	out := formatter.formatTarget(result, units)
 	if dm.Brief {
 		out = shrinkPeriod(out)
 	}
-	out = strings.TrimSpace(out)
-	if negative && !dm.Absolute {
-		out = "-" + out
-	}
-	return out, nil
+	return strings.TrimSpace(out), nil
 }

--- a/durmath_test.go
+++ b/durmath_test.go
@@ -134,6 +134,11 @@ func TestDurMathSubSecond(t *testing.T) {
 	testDurMath(t, "1 second", "500 milliseconds", false, false, "1 second 500 milliseconds", "500 milliseconds")
 	// whole-second results stay at second granularity
 	testDurMath(t, "750 milliseconds", "250 milliseconds", false, false, "1 second", "500 milliseconds")
+	// float-imprecise operands round to the nearest nanosecond, so the
+	// result is exact instead of 199ms 999us 999ns
+	testDurMath(t, "0.3 seconds", "0.1 seconds", false, false, "400 milliseconds", "200 milliseconds")
+	// decimals rounding carries into the larger unit
+	testDurMathConv(t, "1 minute 59.96 seconds", "0 seconds", "minutes seconds", false, 1, false, "2 minutes 0.0 seconds", "2 minutes 0.0 seconds")
 }
 
 func TestDurMathZeroResult(t *testing.T) {
@@ -156,6 +161,7 @@ func TestDurMathInvalidInput(t *testing.T) {
 		{name: "empty first", first: "", second: "1 hour"},
 		{name: "empty second", first: "1 hour", second: ""},
 		{name: "whitespace-only target", first: "1 hour", second: "1 hour", target: "   "},
+		{name: "bare-dot target", first: "1 hour", second: "1 hour", target: "."},
 		{name: "month in first", first: "1 month", second: "1 hour"},
 		{name: "month in second", first: "1 hour", second: "1 month"},
 		{name: "decimals below range", first: "1 hour", second: "1 hour", target: "hours", decimals: -1},


### PR DESCRIPTION
# Summary

This PR fixes all 19 open findings from an executed proof-of-concept bug hunt against v1.12.0 (`a06ab73`). Two refactors resolve seven findings; the rest are point fixes. Every fix has a regression test, and every finding was re-verified as gone by re-running the original PoC harness.

## The two refactors

**Shared parsing chain** (BUG-1, BUG-2, BUG-3, BUG-13). All entry points (`fmt`, `dur`, `diff`, `durmath`) now parse date/times through the same `parseDateTimeOrUnix` chain; Diff previously tried carbon first while Dur/Reformat tried parsetime first, so the same string could mean different instants in different sub-commands (`01/02/2024` was Jan 2 in diff, Feb 1 in dur).

**Integer-nanosecond duration engine** (BUG-4, BUG-5, BUG-6, BUG-12). All duration math previously funneled through a single float64 of seconds. Amounts are now parsed and converted in int64 nanoseconds, so integral amounts are exact, unit breakdown is integer div/mod, and decimals rounding carries correctly into larger units.

## Fixes by finding

### P1 - silently wrong results on reasonable input

- **BUG-1**: `Reformat` treated any pure integer as a Unix timestamp (`fmt 20240101 %F` printed `1970-08-23`); it now uses the shared 10/13-digit gate, so `20240101` is a date and `2024` is a year.
- **BUG-2**: one parser order everywhere. Slash dates default to US order (month first) with a new `DTMATE_DATE_ORDER` environment variable (`MDY`/`DMY`) and a stderr warning when an ambiguous date is parsed with the variable unset; `20240101080102` parses as a compact date/time in every sub-command.
- **BUG-3**: leading whitespace no longer bypasses the Unix-timestamp gate (`" 1700265600"` was silently misparsed as today's time-of-day).
- **BUG-4**: net-negative durations render with a leading `-` instead of collapsing to zero (`conv "30 minutes -2 hours" minutes` -> `-90 minutes`).
- **BUG-5**: decimals rounding carries into the next unit (`119.96 seconds` -> `2 minutes 0.0 seconds`, not `1 minute 60.0 seconds`).
- **BUG-6**: no more float truncation cascades (`durmath 0.3s - 0.1s` -> `200 milliseconds`, not `199ms 999us 999ns`).
- **BUG-7**: `diff -c` converts from the exact `time.Duration` instead of re-parsing the human-readable durafmt string with its 365-day year (`diff 2023-01-01 2024-01-01 -c hours` -> `8760 hours`, was `8766`).

### P2 - crashes and wrong results on edge input

- **BUG-8**: conversion target `"."` errored the process with an index-out-of-range panic; it now returns an error.
- **BUG-9**: `fixLocalZone` no longer shifts instants whose zone the user wrote explicitly (RFC850/RFC822-style strings with today's zone abbreviation were moved an hour across the DST boundary).
- **BUG-10**: sub-microsecond diffs render a nanosecond count instead of an empty string; remainders are appended (`1 microsecond 500 nanoseconds`).
- **BUG-11**: `dur -u` with the until date/time opposite the direction of travel errors instead of returning an empty result with no error.
- **BUG-12**: `NaN`, `Inf`, exponent (`1e2`), and hex (`0x1p4`) amounts are rejected; amounts must be plain decimals.
- **BUG-13**: negative timestamps are rejected everywhere with a consistent error, and the ambiguous-length check counts digits, not characters.

### P3 - API design and error-message defects

- **BUG-14**: retired; already fixed by PR #42.
- **BUG-15**: lone `ns`, `us`, and `µs` targets now mean that sub-second unit (previously cryptic errors). A bare `ms` target keeps its historical minutes+seconds meaning for backward compatibility and warns on stderr, since `ms` means milliseconds everywhere else; `.ms` selects milliseconds silently.
- **BUG-16**: brief-target expansion errors name the actual offending token, a trailing dot errors instead of being ignored, and `µs` works as a target.
- **BUG-17**: the 291-calendar-year guard in diff rejected representable spans; it is replaced by a true `time.Duration` saturation check.
- **BUG-18**: `-r/--repeat` is capped at 1,000,000 results, matching the existing until cap (an over-cap repeat previously allocated one result per iteration).
- **BUG-19**: duration grammar cleanups: dur error messages quote the original input instead of leaking the internal brief-to-long expansion, and the expansion placeholders can no longer be injected as units (`"1α"` used to add 1 nanosecond, `"2λ"` two years).

### P4 - documentation

- **BUG-20**: `yesterday`/`tomorrow` are now exactly -/+24 hours as documented, instead of calendar-day arithmetic that spans 23 or 25 real hours on the two DST transition days.

## User-visible behavior changes

- New exported constant `DateOrderEnvVar` (`DTMATE_DATE_ORDER`), mirroring `DTMATE_TZ_ALIASES`.
- Negative integer inputs are rejected as negative timestamps in every sub-command (pre-1970 date strings such as `1950-01-01` are unaffected).
- Pure integers parse deterministically by digit count: 4 = year, 8 = compact date, 10 = Unix seconds, 13 = Unix milliseconds, 14 = compact date/time; all other digit counts error (previously, garbage such as `12345678901234` could silently parse as today's time-of-day).
- `NaN`/`Inf`/exponent/hex duration amounts now error (`1e2 seconds` previously worked in conv).
- Durations are limited to about +/-292 years (int64 nanoseconds); formerly, larger float totals were accepted with degraded precision.
- Lone `ns`/`us`/`µs` targets are newly valid; a bare `ms` target warns.
- `dur -u` on the wrong side of the start (including equal to it) errors.
- Two test pins changed to the now-exact values: `...789 nanoseconds` (was 788) and `...321 nanoseconds` (was 447) - both were float artifacts.

## Documentation

- README: new "Date and Duration Parsing Notes" section, new slash-date and integer-date examples, and the `-c ms` examples now show the ambiguity warning plus a `.ms` milliseconds example.
- `--help-all`: new DATE PARSING section; CONVERSION NOTES cover the range limit and sub-second target rules.

## Verification

- `go test ./...`, `go vet ./...`, `gofmt -l .`, and `go test -race .` are all clean; new regression tests cover every fix.
- The bug report's five-program PoC harness was re-run against the fixed tree with `TZ=America/New_York`: zero findings reproduce.
- CLI repro checklist: panic gone, `8760 hours`, until errors, integer dates, slash-date warning and `DMY` override, negative-timestamp errors, sub-microsecond output, and `dtmate -e` still renders the README examples.
