### PR TITLE
Fix 15 tz bugs from the v1.13.0 bug hunt

### DIFF
--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -23,7 +23,7 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.13.0"
+	ModVersion string = "1.14.0"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 
@@ -138,6 +138,26 @@ var wallClockLayouts = []string{"2006-01-02 15:04:05", "2006-01-02T15:04:05", "2
 // the result (e.g. reformatting "...Z" with %Z must print UTC, not local)
 var zonedLayouts = []string{time.RFC3339Nano, "2006-01-02 15:04:05 -0700 MST", "2006-01-02 15:04:05 -0700", "2006-01-02 15:04:05 MST", time.UnixDate, time.RFC1123Z, time.RFC1123, time.RubyDate}
 
+// zeroOffsetZoneNames holds the zone names that legitimately denote UTC+0
+// in a parsed date/time: the empty name of a bare numeric offset plus the
+// zero-offset abbreviations from the zone table; time.Parse fabricates a
+// zero-offset zone for any abbreviation not defined in the local time
+// zone, so a zero offset under any other name signals a fabricated,
+// silently-wrong parse
+var zeroOffsetZoneNames = buildZeroOffsetZoneNames()
+
+// buildZeroOffsetZoneNames collects the legitimate zero-offset zone names
+// from LoadZoneDefinitions
+func buildZeroOffsetZoneNames() map[string]bool {
+	names := map[string]bool{"": true}
+	for abbrev, def := range LoadZoneDefinitions() {
+		if def.Offset == 0 {
+			names[abbrev] = true
+		}
+	}
+	return names
+}
+
 // isAllDigits reports whether s is non-empty and contains only ASCII digits
 func isAllDigits(s string) bool {
 	if s == "" {
@@ -241,7 +261,21 @@ func parseDateTime(source string) (time.Time, error) {
 	}
 	for _, layout := range zonedLayouts {
 		if t, err := time.Parse(layout, source); err == nil {
-			return t, nil
+			name, offset := t.Zone()
+			if offset != 0 || zeroOffsetZoneNames[strings.ToUpper(name)] {
+				return t, nil
+			}
+			// time.Parse fabricates a zero offset for any zone token it
+			// cannot resolve; ±NN tokens (e.g. "+08") carry their real
+			// offset in the digits, so re-stamp the wall clock into the
+			// zone they actually name instead of keeping the wrong instant
+			if loc, shaped, serr := parseOffsetSuffix(name); shaped {
+				if serr != nil {
+					return time.Time{}, serr
+				}
+				return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), loc), nil
+			}
+			return time.Time{}, fmt.Errorf("zone abbreviation %q is not resolvable in this input position", name)
 		}
 	}
 	if t, claimed, err := parseSlashDate(source); claimed {
@@ -386,10 +420,10 @@ func isUnixTimestamp(s string) bool {
 
 // parseIntegerDateTime parses a pure-integer date/time that is not a Unix
 // timestamp: 4 digits are a year, 8 digits a compact date, and 14 digits a
-// compact date/time, all interpreted in the local time zone; any other
+// compact date/time, all interpreted in the given time zone; any other
 // digit count errors rather than falling through to a parser that would
 // misread the digits as a time of day on the current date
-func parseIntegerDateTime(source string) (time.Time, error) {
+func parseIntegerDateTime(source string, loc *time.Location) (time.Time, error) {
 	var layout string
 	switch timestampDigits(source) {
 	case 4:
@@ -401,7 +435,7 @@ func parseIntegerDateTime(source string) (time.Time, error) {
 	default:
 		return time.Time{}, fmt.Errorf("ambiguous integer date/time %q: expected 4 digits (year), 8 (date), 10 (seconds), 13 (milliseconds), or 14 (date/time)", source)
 	}
-	t, err := time.ParseInLocation(layout, source, time.Local)
+	t, err := time.ParseInLocation(layout, source, loc)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("unable to parse integer date/time %q: %w", source, err)
 	}
@@ -422,7 +456,7 @@ func parseDateTimeOrUnix(source string) (time.Time, error) {
 		if isUnixTimestamp(source) {
 			return unixStringToTime(source)
 		}
-		return parseIntegerDateTime(source)
+		return parseIntegerDateTime(source, time.Local)
 	}
 	return parseDateTime(ConvertRelativeDateToActual(source))
 }

--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ The command-line program, `dtmate` *(along with the golang package)* allows you 
 <summary>7. Convert a date/time from one time zone to another?</summary>
 
 `dtmate tz "2024-01-15 12:00:00 UTC" America/New_York`
-* answer: `2024-01-15 07:00:00 EST`
+* answer: `2024-01-15 07:00:00 -0500 EST`
 * zones can be given in multiple styles:
-* * IANA names such as `America/New_York`, `Asia/Kolkata`, `Australia/Eucla` *(preferred; these are DST aware)*
+* * IANA names such as `America/New_York`, `Asia/Kolkata`, `Australia/Eucla` *(preferred; these are DST aware and case-insensitive)*
 * * abbreviations such as `EST`, `JST`, `pst` *(case-insensitive, fixed offsets)*
 * * UTC offsets in seconds, such as `19800` for UTC+5:30
+* the source may also be a unix timestamp in seconds or milliseconds, such as `1700265600`
 * pin ambiguous abbreviations with an environment variable: `DTMATE_TZ_ALIASES="IST=Asia/Jerusalem|CST=Asia/Shanghai"`
 * list all supported abbreviations: `dtmate tz --list-zones`
 * list all IANA zone names with their current offsets: `dtmate tz --list-iana`
@@ -511,40 +512,44 @@ $ DTMATE_DATE_ORDER=DMY dtmate fmt 01/02/2024 "%F"
 
 # convert using IANA zone names (preferred; these are DST aware)
 $ dtmate tz "2024-01-15 12:00:00 UTC" America/New_York
-2024-01-15 07:00:00 EST
+2024-01-15 07:00:00 -0500 EST
 
 # the same source in July automatically yields daylight time
 $ dtmate tz "2024-07-04 08:00:00 EDT" Europe/Paris
-2024-07-04 14:00:00 CEST
+2024-07-04 14:00:00 +0200 CEST
 
 # abbreviations work for both the source and the target
 $ dtmate tz "2024-01-15 09:00:00 PST" JST
-2024-01-16 02:00:00 JST
+2024-01-16 02:00:00 +0900 JST
 
-# abbreviations are case-insensitive
+# abbreviations and IANA names are case-insensitive
 $ dtmate tz "2024-01-15 12:00:00 UTC" jst
-2024-01-15 21:00:00 JST
+2024-01-15 21:00:00 +0900 JST
 
 # a zone-less source is interpreted as local time
 $ dtmate tz "2024-01-15 12:00:00" UTC
-2024-01-15 17:00:00 UTC
+2024-01-15 17:00:00 +0000 UTC
+
+# a unix timestamp in seconds or milliseconds also works as the source
+$ dtmate tz "1700265600" UTC
+2023-11-18 00:00:00 +0000 UTC
 
 # a UTC offset in seconds is also accepted (19800 = UTC+5:30)
 $ dtmate tz "2024-01-15 12:00:00 UTC" 19800
-2024-01-15 17:30:00 UTC+5
+2024-01-15 17:30:00 +0530 UTC+05:30
 
 # ambiguous abbreviations warn on stderr and use their primary meaning
 $ dtmate tz "2024-01-15 12:00:00 UTC" IST
 warning: IST is ambiguous: using India Standard Time (UTC+05:30), not Israel Standard Time (UTC+2), Irish Standard Time (UTC+1); set DTMATE_TZ_ALIASES="IST=<IANA zone>" to override
-2024-01-15 17:30:00 IST
+2024-01-15 17:30:00 +0530 IST
 
 # pin an ambiguous abbreviation to an IANA zone; aliases stay DST aware
 $ DTMATE_TZ_ALIASES="IST=Asia/Jerusalem" dtmate tz "2024-07-15 12:00:00 UTC" IST
-2024-07-15 15:00:00 IDT
+2024-07-15 15:00:00 +0300 IDT
 
 # multiple aliases are pipe-delimited
 $ DTMATE_TZ_ALIASES="IST=Asia/Jerusalem|CST=Asia/Shanghai" dtmate tz "2024-01-15 12:00:00 UTC" CST
-2024-01-15 20:00:00 CST
+2024-01-15 20:00:00 +0800 CST
 
 # list the supported abbreviations
 $ dtmate tz --list-zones
@@ -555,6 +560,7 @@ ACWST  UTC+08:45  Australian Central Western Standard Time
 
 # list the IANA zone names with the offset currently in effect there
 $ dtmate tz --list-iana
+offsets and abbreviations are those currently in effect (2026-07-07)
 Africa/Abidjan                   UTC+00:00 (GMT)
 Africa/Accra                     UTC+00:00 (GMT)
 ...
@@ -571,7 +577,7 @@ Australia/Sydney                 UTC+10:00 (AEST)
 # date/times before 1970 are rejected by default because time zone
 # data is unreliable before then; use --force to convert anyway
 $ dtmate tz --force "1900-02-28 23:59:59 UTC" Europe/London
-1900-02-28 23:59:59 GMT
+1900-02-28 23:59:59 +0000 GMT
 ```
 </details>
 

--- a/cmd/dtmate/cmd/tz.go
+++ b/cmd/dtmate/cmd/tz.go
@@ -21,7 +21,7 @@ var tzCmd = &cobra.Command{
 	Short: "Convert a date/time from one time zone to another",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if optTzListZones || optTzListIANA {
-			return nil
+			return cobra.NoArgs(cmd, args)
 		}
 		return cobra.ExactArgs(2)(cmd, args)
 	},
@@ -43,6 +43,7 @@ func init() {
 	tzCmd.Flags().BoolVarP(&optTzListZones, "list-zones", "l", false, "list the supported time zone abbreviations and exit")
 	tzCmd.Flags().BoolVarP(&optTzListIANA, "list-iana", "I", false, "list the IANA time zone names (e.g. America/New_York) and exit")
 	tzCmd.Flags().BoolVarP(&optTzForce, "force", "f", false, "convert date/times before 1970 despite unreliable time zone data")
+	tzCmd.MarkFlagsMutuallyExclusive("list-zones", "list-iana")
 }
 
 func newTimeZoneConverter() *DateTimeMate.TimeZoneConverter {
@@ -59,9 +60,6 @@ func newTimeZoneConverter() *DateTimeMate.TimeZoneConverter {
 
 func outputTzConversion(source, target string) {
 	tz := newTimeZoneConverter()
-	for _, warning := range tz.Warnings(source, target) {
-		fmt.Fprintln(os.Stderr, "warning:", warning)
-	}
 	result, err := tz.ConvertTimeZone(source, target)
 	if err != nil {
 		if errors.Is(err, DateTimeMate.ErrPre1970) {
@@ -71,7 +69,10 @@ func outputTzConversion(source, target string) {
 		}
 		os.Exit(1)
 	}
-	formatted := result.Format("2006-01-02 15:04:05 MST")
+	for _, warning := range tz.Warnings(source, target) {
+		fmt.Fprintln(os.Stderr, "warning:", warning)
+	}
+	formatted := result.Format("2006-01-02 15:04:05 -0700 MST")
 	if optRootNoNewline {
 		fmt.Print(formatted)
 	} else {
@@ -87,9 +88,14 @@ func listZones() {
 		if def.Ambiguous != "" {
 			note = " [ambiguous; also: " + def.Ambiguous + "]"
 		}
+		if isDSTAwareAbbrev(abbrev) {
+			note += " [DST aware]"
+		}
 		fmt.Printf("%-6s UTC%s  %s%s\n", abbrev, DateTimeMate.FormatUTCOffset(def.Offset), def.Description, note)
 	}
 	fmt.Println()
+	fmt.Println("Abbreviations marked [DST aware] resolve as IANA zones and follow their DST")
+	fmt.Println("rules; the offset shown for them is their standard (winter) offset.")
 	fmt.Println("IANA zone names such as America/New_York or Asia/Kolkata are also supported")
 	fmt.Println("and preferred: unlike the fixed offsets above, they are DST aware.")
 	fmt.Println("List them with: dtmate tz --list-iana")
@@ -97,10 +103,27 @@ func listZones() {
 	fmt.Printf("variable, e.g. %s=\"IST=Asia/Jerusalem|CST=Asia/Shanghai\"\n", DateTimeMate.ZoneAliasesEnvVar)
 }
 
+// isDSTAwareAbbrev reports whether an abbreviation resolves as an IANA
+// zone whose UTC offset changes over the year (e.g. CET), meaning the
+// fixed offset shown in the abbreviation table only applies in winter;
+// conversions resolve IANA names before the abbreviation table, so such
+// entries are DST aware in practice
+func isDSTAwareAbbrev(abbrev string) bool {
+	loc, err := time.LoadLocation(abbrev)
+	if err != nil {
+		return false
+	}
+	year := time.Now().Year()
+	_, january := time.Date(year, time.January, 15, 12, 0, 0, 0, time.UTC).In(loc).Zone()
+	_, july := time.Date(year, time.July, 15, 12, 0, 0, 0, time.UTC).In(loc).Zone()
+	return january != july
+}
+
 // listIANAZones prints each IANA zone name with the UTC offset and
 // abbreviation currently in effect there
 func listIANAZones() {
 	now := time.Now()
+	fmt.Printf("offsets and abbreviations are those currently in effect (%s)\n", now.Format("2006-01-02"))
 	for _, name := range DateTimeMate.ListIANAZones() {
 		loc, err := time.LoadLocation(name)
 		if err != nil {

--- a/timezone.go
+++ b/timezone.go
@@ -70,16 +70,23 @@ func ParseZoneAliases(spec string) (map[string]string, error) {
 	}
 	aliases := make(map[string]string)
 	for _, pair := range strings.Split(spec, "|") {
+		if strings.TrimSpace(pair) == "" {
+			continue
+		}
 		abbrev, zone, found := strings.Cut(pair, "=")
 		abbrev = strings.TrimSpace(abbrev)
 		zone = strings.TrimSpace(zone)
 		if !found || abbrev == "" || zone == "" {
 			return nil, fmt.Errorf("invalid alias %q: expected ABBREVIATION=IANA-zone", pair)
 		}
-		if _, err := time.LoadLocation(zone); err != nil {
+		if _, err := loadIANALocation(zone); err != nil {
 			return nil, fmt.Errorf("invalid alias %q: %q is not an IANA time zone", pair, zone)
 		}
-		aliases[strings.ToUpper(abbrev)] = zone
+		key := strings.ToUpper(abbrev)
+		if existing, ok := aliases[key]; ok {
+			return nil, fmt.Errorf("duplicate alias %q: %s and %s", key, existing, zone)
+		}
+		aliases[key] = zone
 	}
 	return aliases, nil
 }
@@ -169,72 +176,179 @@ func FormatUTCOffset(seconds int) string {
 }
 
 // parseSourceTime parses a date/time string; when the last field names a
-// resolvable time zone, the preceding wall clock is interpreted in that
-// zone, otherwise the whole string is parsed as a local date/time
+// resolvable time zone or a ±HH UTC offset, the preceding wall clock is
+// interpreted in that zone, otherwise the whole string is parsed as a
+// local date/time, with 10 and 13 digit integers read as unix timestamps
 func (c *TimeZoneConverter) parseSourceTime(input string) (time.Time, error) {
 	if idx := strings.LastIndex(input, " "); idx != -1 {
-		zone := input[idx+1:]
-		if isZoneName(zone) {
-			if loc, err := c.resolveLocation(zone); err == nil {
-				wall := strings.TrimSpace(input[:idx])
-				for _, layout := range wallClockLayouts {
-					if t, err := time.ParseInLocation(layout, wall, loc); err == nil {
-						return t, nil
-					}
-				}
-				t, err := parseDateTime(wall)
-				if err != nil {
-					return time.Time{}, err
-				}
-				return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), loc), nil
+		token := input[idx+1:]
+		wall := strings.TrimSpace(input[:idx])
+		loc, shaped, err := parseOffsetSuffix(token)
+		if err != nil {
+			return time.Time{}, err
+		}
+		if !shaped && isZoneName(token) {
+			if resolved, rerr := c.resolveLocation(token); rerr == nil {
+				loc = resolved
 			}
 		}
+		if loc != nil {
+			return c.parseWallClockIn(input, wall, token, loc)
+		}
 	}
-	return parseDateTime(ConvertRelativeDateToActual(input))
+	return parseDateTimeOrUnix(input)
+}
+
+// parseWallClockIn interprets the wall clock preceding a trailing zone
+// token in that zone; relative words and unix timestamps are rejected
+// because they already denote an instant, and a wall clock carrying its
+// own explicit zone or offset must agree with the trailing zone
+func (c *TimeZoneConverter) parseWallClockIn(input, wall, zone string, loc *time.Location) (time.Time, error) {
+	if ConvertRelativeDateToActual(wall) != wall {
+		return time.Time{}, fmt.Errorf("relative date/times cannot carry a time zone: %q", input)
+	}
+	if isPureIntegerAtoi(wall) {
+		if isUnixTimestamp(wall) {
+			return time.Time{}, fmt.Errorf("a unix timestamp cannot carry a time zone: %q", input)
+		}
+		return parseIntegerDateTime(wall, loc)
+	}
+	for _, layout := range wallClockLayouts {
+		if t, err := time.ParseInLocation(layout, wall, loc); err == nil {
+			return t, nil
+		}
+	}
+	t, err := parseDateTime(wall)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if sourceHasExplicitZone(wall, t) {
+		return reconcileZones(t, zone, loc)
+	}
+	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), loc), nil
+}
+
+// reconcileZones handles a wall clock that carried its own zone or offset
+// in addition to the trailing zone token: when both denote the same UTC
+// offset at that instant the parsed instant is kept, otherwise the source
+// is contradictory and rejected
+func reconcileZones(t time.Time, zone string, loc *time.Location) (time.Time, error) {
+	_, wallOffset := t.Zone()
+	_, locOffset := t.In(loc).Zone()
+	if wallOffset != locOffset {
+		return time.Time{}, fmt.Errorf("source names both UTC%s and %s (UTC%s)", FormatUTCOffset(wallOffset), zone, FormatUTCOffset(locOffset))
+	}
+	return t.In(loc), nil
+}
+
+// parseOffsetSuffix interprets a ±NN field as a whole-hour UTC offset
+// (e.g. "+08" or "-12", the abbreviation form many IANA zones print),
+// used both for trailing source fields and for repairing zone tokens that
+// time.Parse fabricated; ±NNNN fields are left to the date/time parser's
+// -0700 layout. shaped reports whether the field has the ±NN form at all:
+// a shaped but out-of-range field errors rather than falling through to
+// parsers that would silently drop it
+func parseOffsetSuffix(token string) (loc *time.Location, shaped bool, err error) {
+	if len(token) != 3 || (token[0] != '+' && token[0] != '-') || !isAllDigits(token[1:]) {
+		return nil, false, nil
+	}
+	hours, _ := strconv.Atoi(token[1:])
+	seconds := hours * 3600
+	if token[0] == '-' {
+		seconds = -seconds
+	}
+	if seconds < -43200 || seconds > 50400 {
+		return nil, true, fmt.Errorf("offset %q out of valid range (-12:00 to +14:00)", token)
+	}
+	return time.FixedZone(token, seconds), true, nil
 }
 
 // isZoneName reports whether a field can name a time zone: an IANA path
-// such as America/New_York or an alphabetic abbreviation such as EST;
-// numeric fields (e.g. "-0500") are left to the date/time parser
+// such as America/New_York, an alphabetic abbreviation such as EST, or a
+// letters-and-digits IANA name such as EST5EDT; pure-numeric and signed
+// fields (e.g. "-0500") are left to the offset and date/time parsers
 func isZoneName(s string) bool {
 	if strings.Contains(s, "/") {
 		return true
 	}
+	hasLetter := false
 	for _, r := range s {
-		if !unicode.IsLetter(r) {
+		switch {
+		case unicode.IsLetter(r):
+			hasLetter = true
+		case unicode.IsDigit(r):
+		default:
 			return false
 		}
 	}
-	return s != ""
+	return hasLetter
 }
 
 // resolveLocation resolves a time zone given as an aliased abbreviation,
-// an IANA name (DST aware), an abbreviation from ZoneAbbrevs, or a UTC
-// offset in seconds
+// an IANA name (DST aware, case-insensitive), an abbreviation from
+// ZoneAbbrevs, or a UTC offset in seconds
 func (c *TimeZoneConverter) resolveLocation(zone string) (*time.Location, error) {
 	upper := strings.ToUpper(zone)
 	if target, ok := c.Aliases[upper]; ok {
-		loc, err := time.LoadLocation(target)
+		loc, err := loadIANALocation(target)
 		if err != nil {
 			return nil, fmt.Errorf("%w: alias %s=%s does not name an IANA time zone", ErrInvalidTimezone, upper, target)
 		}
 		return loc, nil
 	}
-	if loc, err := time.LoadLocation(zone); err == nil {
+	if loc, err := loadIANALocation(zone); err == nil {
 		return loc, nil
 	}
 	if def, ok := c.ZoneAbbrevs[upper]; ok {
 		return time.FixedZone(upper, def.Offset), nil
 	}
-	if offset, err := parseOffset(zone); err == nil {
-		return time.FixedZone(fmt.Sprintf("UTC%+d", offset/3600), offset), nil
+	offset, err := parseOffset(zone)
+	if err == nil {
+		return time.FixedZone("UTC"+FormatUTCOffset(offset), offset), nil
+	}
+	if len(zone) > 0 && (zone[0] == '+' || zone[0] == '-' || (zone[0] >= '0' && zone[0] <= '9')) {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidTimezone, err)
 	}
 	return nil, ErrInvalidTimezone
 }
 
+// ianaZoneFold maps each generated IANA zone name, lowercased, to its
+// canonical spelling so lookups are case-insensitive on every platform:
+// filesystem lookups happen to be case-insensitive on macOS but not on
+// Linux or in the embedded time/tzdata fallback
+var ianaZoneFold = buildIANAZoneFold()
+
+// buildIANAZoneFold builds the lowercased-to-canonical zone name map from
+// the generated ianaZoneNames list
+func buildIANAZoneFold() map[string]string {
+	fold := make(map[string]string, len(ianaZoneNames))
+	for _, name := range ianaZoneNames {
+		fold[strings.ToLower(name)] = name
+	}
+	return fold
+}
+
+// loadIANALocation loads an IANA time zone by name, case-insensitively:
+// the name is canonicalized against the generated zone list first, and
+// names not on the list fall back to a direct lookup
+func loadIANALocation(name string) (*time.Location, error) {
+	if canonical, ok := ianaZoneFold[strings.ToLower(name)]; ok {
+		name = canonical
+	}
+	return time.LoadLocation(name)
+}
+
 // parseOffset parses a UTC offset given in seconds (e.g. "19800" or
-// "-34200") and validates it falls within -12:00 to +14:00
+// "-34200") and validates it falls within -12:00 to +14:00; sign-prefixed
+// 3-4 digit values are rejected because the user almost certainly meant
+// ±HHMM, not seconds
 func parseOffset(offset string) (int, error) {
+	if len(offset) > 1 && (offset[0] == '+' || offset[0] == '-') {
+		digits := offset[1:]
+		if isAllDigits(digits) && (len(digits) == 3 || len(digits) == 4) {
+			return 0, hhmmOffsetError(offset, digits)
+		}
+	}
 	seconds, err := strconv.Atoi(strings.TrimPrefix(offset, "+"))
 	if err != nil {
 		return 0, fmt.Errorf("invalid offset %q: %w", offset, err)
@@ -243,4 +357,20 @@ func parseOffset(offset string) (int, error) {
 		return 0, fmt.Errorf("offset %q out of valid range (-12:00 to +14:00)", offset)
 	}
 	return seconds, nil
+}
+
+// hhmmOffsetError builds the rejection for a sign-prefixed 3-4 digit
+// offset, suggesting the equivalent value in seconds when the digits form
+// a valid ±HHMM reading
+func hhmmOffsetError(offset, digits string) error {
+	hours, _ := strconv.Atoi(digits[:len(digits)-2])
+	minutes, _ := strconv.Atoi(digits[len(digits)-2:])
+	if minutes > 59 {
+		return fmt.Errorf("offset %q looks like HH:MM; offsets are in seconds", offset)
+	}
+	seconds := hours*3600 + minutes*60
+	if offset[0] == '-' {
+		seconds = -seconds
+	}
+	return fmt.Errorf("offset %q looks like HH:MM; offsets are in seconds (use %d for %s)", offset, seconds, FormatUTCOffset(seconds))
 }

--- a/timezone_fix_test.go
+++ b/timezone_fix_test.go
@@ -1,0 +1,247 @@
+// timezone_fix_test.go pins the behaviors introduced by the tz bug-fix
+// batch (findings TZ-1 through TZ-12 of the v1.13.0 tz bug hunt): unix
+// timestamp sources, rejection of contradictory zone combinations, ±HH
+// offset suffixes, offset error propagation, case-insensitive IANA names,
+// and alias parsing edge cases. Unlike the original timezone_test.go it
+// uses only the standard testing package, per current repo policy.
+// Instants are compared via Unix seconds so results do not depend on the
+// time zone of the machine running the tests.
+package DateTimeMate
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// mustConvertUnix converts and returns the instant as Unix seconds,
+// failing the test on error
+func mustConvertUnix(t *testing.T, conv *TimeZoneConverter, source, target string) int64 {
+	t.Helper()
+	result, err := conv.ConvertTimeZone(source, target)
+	if err != nil {
+		t.Fatalf("ConvertTimeZone(%q, %q) unexpected error: %v", source, target, err)
+	}
+	return result.Unix()
+}
+
+// mustFailConvert converts, requires an error, and requires the error
+// message to contain want
+func mustFailConvert(t *testing.T, conv *TimeZoneConverter, source, target, want string) {
+	t.Helper()
+	_, err := conv.ConvertTimeZone(source, target)
+	if err == nil {
+		t.Fatalf("ConvertTimeZone(%q, %q) expected an error containing %q, got none", source, target, want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("ConvertTimeZone(%q, %q) error %q does not contain %q", source, target, err, want)
+	}
+}
+
+func TestTimezoneUnixTimestampSources(t *testing.T) {
+	conv := setupConverter()
+
+	// TZ-1: 10-digit seconds and 13-digit milliseconds parse as unix
+	// timestamps, consistent with the fmt sub-command
+	if got := mustConvertUnix(t, conv, "1700265600", "UTC"); got != 1700265600 {
+		t.Errorf("10-digit source: got unix %d, want 1700265600", got)
+	}
+	if got := mustConvertUnix(t, conv, "1700265600000", "UTC"); got != 1700265600 {
+		t.Errorf("13-digit source: got unix %d, want 1700265600", got)
+	}
+
+	// TZ-1: other bare-integer digit counts error instead of being
+	// misread as a time of day on the current date
+	mustFailConvert(t, conv, "19800", "UTC", "ambiguous integer date/time")
+
+	// TZ-1 (decided): a unix timestamp already denotes an instant, so a
+	// zone suffix is contradictory
+	mustFailConvert(t, conv, "1700265600 UTC", "America/New_York", "unix timestamp cannot carry a time zone")
+
+	// compact integer date/times with a zone suffix keep working and are
+	// interpreted in that zone
+	want := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC).Unix()
+	if got := mustConvertUnix(t, conv, "20240115120000 UTC", "EST"); got != want {
+		t.Errorf("14-digit source with zone: got unix %d, want %d", got, want)
+	}
+}
+
+func TestTimezoneRelativeWordsWithZone(t *testing.T) {
+	conv := setupConverter()
+
+	// TZ-4 (decided): relative words already denote an instant
+	mustFailConvert(t, conv, "now UTC", "America/New_York", "relative date/times cannot carry a time zone")
+	mustFailConvert(t, conv, "tomorrow EST", "UTC", "relative date/times cannot carry a time zone")
+
+	// bare relative words keep working
+	if _, err := conv.ConvertTimeZone("tomorrow", "UTC"); err != nil {
+		t.Errorf("bare relative word: unexpected error: %v", err)
+	}
+}
+
+func TestTimezoneFabricatedAbbreviationRejected(t *testing.T) {
+	conv := setupConverter()
+
+	// TZ-2: an abbreviation in non-final position that the local time
+	// zone does not define must error loudly, not silently parse as UTC+0
+	mustFailConvert(t, conv, "Mon Jan 15 07:00:00 XYZ 2024", "UTC", `zone abbreviation "XYZ" is not resolvable`)
+
+	// the same guard protects the shared parse chain used by fmt
+	if _, err := Reformat("Mon Jan 15 07:00:00 XYZ 2024", "%Y-%m-%d"); err == nil {
+		t.Error("Reformat with a fabricated abbreviation: expected an error, got none")
+	}
+
+	// numeric ±NN zone tokens are repairable, not fabricated: the digits
+	// carry the real offset, so the shared chain honors it instead of the
+	// zero offset time.Parse invents
+	if got, err := Reformat("2024-01-15 20:00:00 +08", "%Y-%m-%dT%H:%M:%S %z"); err != nil || got != "2024-01-15T20:00:00 +0800" {
+		t.Errorf("Reformat +08: got %q, %v; want \"2024-01-15T20:00:00 +0800\"", got, err)
+	}
+
+	// "+00" legitimately denotes UTC+0 (e.g. Antarctica/Troll) and must
+	// not be rejected
+	if got, err := Reformat("2024-01-15 12:00:00 +00", "%z"); err != nil || got != "+0000" {
+		t.Errorf("Reformat +00: got %q, %v; want \"+0000\"", got, err)
+	}
+}
+
+func TestTimezoneOffsetSuffixSources(t *testing.T) {
+	conv := setupConverter()
+	want := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC).Unix()
+
+	// TZ-3a: trailing ±NN tokens are whole-hour UTC offsets, the
+	// abbreviation form many IANA zones print
+	if got := mustConvertUnix(t, conv, "2024-01-15 20:00:00 +08", "UTC"); got != want {
+		t.Errorf("+08 suffix: got unix %d, want %d", got, want)
+	}
+	if got := mustConvertUnix(t, conv, "2024-01-15 00:00:00 -12", "UTC"); got != want {
+		t.Errorf("-12 suffix: got unix %d, want %d", got, want)
+	}
+
+	// a ±NN suffix outside -12:00..+14:00 errors instead of being
+	// silently dropped by a fallback parser
+	mustFailConvert(t, conv, "2024-01-15 12:00:00 +15", "UTC", "out of valid range")
+}
+
+func TestTimezoneOutputFormatRoundTrip(t *testing.T) {
+	conv := setupConverter()
+	const cliFormat = "2006-01-02 15:04:05 -0700 MST"
+	want := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC).Unix()
+
+	// TZ-3b: the CLI output format re-parses to the same instant, even
+	// for zones with numeric abbreviations such as +08 and -12
+	for _, target := range []string{"Antarctica/Casey", "Etc/GMT+12", "America/New_York", "Asia/Kathmandu"} {
+		result, err := conv.ConvertTimeZone("2024-01-15 12:00:00 UTC", target)
+		if err != nil {
+			t.Fatalf("convert to %s: %v", target, err)
+		}
+		formatted := result.Format(cliFormat)
+		if got := mustConvertUnix(t, conv, formatted, "UTC"); got != want {
+			t.Errorf("round trip via %s (%q): got unix %d, want %d", target, formatted, got, want)
+		}
+	}
+}
+
+func TestTimezoneConflictingSourceZones(t *testing.T) {
+	conv := setupConverter()
+
+	// TZ-10 (decided): a wall clock carrying its own offset that
+	// disagrees with the trailing zone is contradictory
+	mustFailConvert(t, conv, "2024-01-15 12:00:00 +0900 EST", "UTC", "source names both")
+
+	// when they agree, the parse is accepted and the offset is honored
+	want := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC).Unix()
+	if got := mustConvertUnix(t, conv, "2024-01-15 07:00:00 -0500 EST", "UTC"); got != want {
+		t.Errorf("agreeing offset and zone: got unix %d, want %d", got, want)
+	}
+
+	// the Jerusalem round trip: without an alias, IST resolves to India
+	// (+05:30) which disagrees with +0200 and must error loudly
+	mustFailConvert(t, conv, "2024-01-15 14:00:00 +0200 IST", "UTC", "source names both")
+
+	// with the alias, IST resolves to Asia/Jerusalem (+02:00 in January),
+	// the offsets agree, and the round trip is exact
+	aliases, err := ParseZoneAliases("IST=Asia/Jerusalem")
+	if err != nil {
+		t.Fatalf("ParseZoneAliases: %v", err)
+	}
+	aliased := NewTimeZoneConverter(
+		TimeZoneConverterWithZoneAbbrevs(LoadZoneDefinitions()),
+		TimeZoneConverterWithAliases(aliases))
+	if got := mustConvertUnix(t, aliased, "2024-01-15 14:00:00 +0200 IST", "UTC"); got != want {
+		t.Errorf("aliased IST round trip: got unix %d, want %d", got, want)
+	}
+}
+
+func TestTimezoneSecondsOffsetTargets(t *testing.T) {
+	conv := setupConverter()
+
+	// TZ-5 (decided): sign-prefixed 3-4 digit targets read as ±HHMM, so
+	// reject them with the equivalent value in seconds; TZ-8 makes the
+	// detail visible instead of a bare "invalid timezone specification"
+	mustFailConvert(t, conv, "2024-01-15 12:00:00 UTC", "+0530", "use 19800 for +05:30")
+	mustFailConvert(t, conv, "2024-01-15 12:00:00 UTC", "-0500", "use -18000 for -05:00")
+
+	// TZ-8: the range message reaches the user
+	mustFailConvert(t, conv, "2024-01-15 12:00:00 UTC", "50401", "out of valid range")
+
+	// bare digit strings remain seconds, now labeled without truncation
+	// (TZ-9)
+	result, err := conv.ConvertTimeZone("2024-01-15 12:00:00 UTC", "19800")
+	if err != nil {
+		t.Fatalf("seconds target: %v", err)
+	}
+	if name, _ := result.Zone(); name != "UTC+05:30" {
+		t.Errorf("seconds target zone name: got %q, want \"UTC+05:30\"", name)
+	}
+}
+
+func TestTimezoneCaseInsensitiveIANANames(t *testing.T) {
+	conv := setupConverter()
+	want := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC).Unix()
+
+	// TZ-7 (decided): IANA names are case-insensitive on every platform,
+	// as both target and source
+	if got := mustConvertUnix(t, conv, "2024-01-15 12:00:00 UTC", "america/new_york"); got != want {
+		t.Errorf("lowercase target: got unix %d, want %d", got, want)
+	}
+	if got := mustConvertUnix(t, conv, "2024-01-15 21:00:00 asia/tokyo", "UTC"); got != want {
+		t.Errorf("lowercase source: got unix %d, want %d", got, want)
+	}
+
+	// alias values are canonicalized the same way
+	if _, err := ParseZoneAliases("IST=asia/jerusalem"); err != nil {
+		t.Errorf("lowercase alias value: unexpected error: %v", err)
+	}
+}
+
+func TestTimezoneDigitBearingZoneNames(t *testing.T) {
+	conv := setupConverter()
+
+	// TZ-11: IANA names containing digits work as a source zone suffix
+	want := time.Date(2024, 7, 15, 12, 0, 0, 0, time.UTC).Unix()
+	if got := mustConvertUnix(t, conv, "2024-07-15 08:00:00 EST5EDT", "UTC"); got != want {
+		t.Errorf("EST5EDT source: got unix %d, want %d", got, want)
+	}
+}
+
+func TestTimezoneAliasSpecEdgeCases(t *testing.T) {
+	// TZ-12 (decided): empty segments from trailing or doubled pipes are
+	// skipped
+	aliases, err := ParseZoneAliases("IST=Asia/Jerusalem|")
+	if err != nil {
+		t.Fatalf("trailing pipe: unexpected error: %v", err)
+	}
+	if len(aliases) != 1 || aliases["IST"] != "Asia/Jerusalem" {
+		t.Errorf("trailing pipe: got %v, want map[IST:Asia/Jerusalem]", aliases)
+	}
+
+	// TZ-12 (decided): duplicate keys error instead of silently last-winning
+	_, err = ParseZoneAliases("IST=Asia/Jerusalem|IST=Asia/Kolkata")
+	if err == nil {
+		t.Fatal("duplicate alias keys: expected an error, got none")
+	}
+	if !strings.Contains(err.Error(), `duplicate alias "IST"`) {
+		t.Errorf("duplicate alias keys: error %q does not name the duplicate", err)
+	}
+}

--- a/timezone_test.go
+++ b/timezone_test.go
@@ -234,13 +234,13 @@ func TestTimezoneNumericOffsets(t *testing.T) {
 			name:       "UTC to +0530",
 			sourceTime: "2024-01-15 12:00:00 UTC",
 			targetZone: "19800", // +5:30 in seconds
-			expected:   "2024-01-15 17:30:00 UTC+5",
+			expected:   "2024-01-15 17:30:00 UTC+05:30",
 		},
 		{
 			name:       "UTC to -0930",
 			sourceTime: "2024-01-15 12:00:00 UTC",
 			targetZone: "-34200", // -9:30 in seconds
-			expected:   "2024-01-15 02:30:00 UTC-9",
+			expected:   "2024-01-15 02:30:00 UTC-09:30",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Implements all 15 decided fixes from the tz bug hunt against v1.13.0 (`0842722`). Every user-visible behavior choice follows the maintainer decisions recorded on 2026-07-07.

## Correctness (P1/P2)

- **TZ-1**: `tz` now routes zone-less sources through the same unix-timestamp-aware parser as `fmt`: `"1700265600"` converts to `2023-11-18 00:00:00 UTC` instead of a run-date-dependent time of day. Ambiguous digit counts (5/6/7/9/11/12) error loudly. A unix timestamp with a zone suffix (`"1700265600 UTC"`) is rejected as contradictory.
- **TZ-2**: abbreviations `time.Parse` cannot resolve (e.g. `PST` in UnixDate position under a non-US TZ) error loudly instead of silently parsing as UTC+0. Signed numeric tokens (`+08`) are repaired from their self-describing digits instead. This hardens the shared parse chain used by `fmt`, `diff`, and `dur` too.
- **TZ-3**: trailing `+NN`/`-NN` source tokens parse as whole-hour UTC offsets, and the CLI output format is now `2006-01-02 15:04:05 -0700 MST`, so every `tz` output re-parses to the same instant (including `+08`/`-12` zones).
- **TZ-4**: relative words with a zone suffix (`"now UTC"`) are rejected; bare relative words keep working.
- **TZ-5**: sign-prefixed 3-4 digit second offsets are rejected with a hint: `offset "+0530" looks like HH:MM; offsets are in seconds (use 19800 for +05:30)`.

## API and messages (P3)

- **TZ-7**: IANA names are case-insensitive everywhere (`america/new_york`), via canonicalization against the generated zone list, so macOS and Linux agree.
- **TZ-8**: `parseOffset` range/syntax details now reach the user.
- **TZ-9**: numeric-offset zones are labeled `UTC+05:30` instead of the truncated `UTC+5`.
- **TZ-10**: a wall-clock offset that disagrees with the trailing zone errors (`source names both UTC+02:00 and IST (UTC+05:30)`); agreement is accepted, which makes the new output format round-trip cleanly (with `DTMATE_TZ_ALIASES="IST=Asia/Jerusalem"` the Jerusalem round trip is exact).
- **TZ-11**: digit-bearing IANA names (`EST5EDT`) work as source zones.
- **TZ-12**: alias specs skip empty pipe segments; duplicate keys error instead of silently last-winning.

## CLI polish (P4)

- **TZ-6**: `--list-zones` marks CET/EET/WET `[DST aware]` (derived from the zone data, so it cannot drift) and explains the shown offset is the winter offset.
- **TZ-13**: warnings print only when the conversion succeeds.
- **TZ-14**: `--list-iana` states its offsets are those currently in effect.
- **TZ-15**: list flags reject positional args and are mutually exclusive.

## Testing

- New `timezone_fix_test.go` (standard `testing` package) pins every new behavior; instants compared via Unix seconds so tests are TZ-independent.
- `TestTimezoneNumericOffsets` updated for the TZ-9 naming change (`UTC+5` -> `UTC+05:30`).
- Full suite passes under `TZ=America/New_York` (the CI TZ); all 15 PoCs from the hunt report re-run against the built binary with the decided behavior; all "verified non-bug" behaviors from the report re-checked unchanged (RFC1123/RubyDate sources, slash-date seam, pre-1970 gate and `--force`, mixed-case abbreviations, `-n`).
- README `tz` examples regenerated for the new output format.
