### PR TITLE
Fix 6 CLI bugs from the v1.14.0 bug hunt; bump version to 1.15.0

### DIFF
--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -23,7 +23,7 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.14.0"
+	ModVersion string = "1.15.0"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 

--- a/cmd/dtmate/cmd/diff.go
+++ b/cmd/dtmate/cmd/diff.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/jftuga/DateTimeMate"
+	"io"
 	"os"
 	"strings"
 
@@ -32,7 +33,11 @@ var diffCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if optDiffReadFromStdin {
-			start, end := getInput()
+			start, end, err := getInput(os.Stdin)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
 			outputDiff(start, end, optDiffBrief)
 			return
 		}
@@ -55,23 +60,43 @@ func init() {
 	diffCmd.Flags().BoolVarP(&optDiffAbsolute, "absolute", "A", false, "always output an absolute (positive) duration")
 }
 
-// either read one line containing a comma, then split start and end on this
-// or read two lines with start on line one and end on line two
-func getInput() (string, string) {
-	input := bufio.NewScanner(os.Stdin)
-	input.Scan()
-	line := input.Text()
-	if strings.Contains(line, ",") {
-		split := strings.Split(line, ",")
-		if len(split) != 2 {
-			fmt.Fprintf(os.Stderr, "invalid stdin input: %s\n", line)
-			os.Exit(1)
+// getInput reads the start and end date/times from r: either one line
+// containing "start,end" or start on line one and end on line two; a
+// non-empty second line takes precedence over a comma in the first line
+// so that dates containing commas (e.g. "Jan 2, 2024") work in two-line mode
+func getInput(r io.Reader) (string, string, error) {
+	const usage = "expected 'start,end' on one line or start and end on two lines"
+	input := bufio.NewScanner(r)
+	if !input.Scan() {
+		if err := input.Err(); err != nil {
+			return "", "", err
 		}
-		return split[0], split[1]
+		return "", "", errors.New("no input on stdin: " + usage)
 	}
-	input.Scan()
-	end := input.Text()
-	return line, end
+	line := strings.TrimSpace(input.Text())
+	var end string
+	if input.Scan() {
+		end = strings.TrimSpace(input.Text())
+	}
+	if err := input.Err(); err != nil {
+		return "", "", err
+	}
+	if end != "" {
+		if line == "" {
+			return "", "", errors.New("invalid stdin input: first line is empty")
+		}
+		return line, end, nil
+	}
+	split := strings.Split(line, ",")
+	if len(split) != 2 {
+		return "", "", fmt.Errorf("invalid stdin input %q: %s", line, usage)
+	}
+	start := strings.TrimSpace(split[0])
+	end = strings.TrimSpace(split[1])
+	if start == "" || end == "" {
+		return "", "", fmt.Errorf("invalid stdin input %q: %s", line, usage)
+	}
+	return start, end, nil
 }
 
 // convert duration from one group of units to another

--- a/cmd/dtmate/cmd/diff_test.go
+++ b/cmd/dtmate/cmd/diff_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		start   string
+		end     string
+		wantErr bool
+	}{
+		{name: "comma pair", input: "15:16:15,15:17\n", start: "15:16:15", end: "15:17"},
+		{name: "comma pair no newline", input: "15:16:15,15:17", start: "15:16:15", end: "15:17"},
+		{name: "comma pair with spaces", input: "2024-01-01, 2024-01-02\n", start: "2024-01-01", end: "2024-01-02"},
+		{name: "two lines", input: "15:16:15\n15:17:20", start: "15:16:15", end: "15:17:20"},
+		{name: "two lines trailing newline", input: "15:16:15\n15:17:20\n", start: "15:16:15", end: "15:17:20"},
+		{name: "two lines with comma dates", input: "Jan 2, 2024\nJan 5, 2024\n", start: "Jan 2, 2024", end: "Jan 5, 2024"},
+		{name: "comma line then blank line", input: "15:16:15,15:17\n\n", start: "15:16:15", end: "15:17"},
+		{name: "empty input", input: "", wantErr: true},
+		{name: "blank line only", input: "\n", wantErr: true},
+		{name: "one line no comma", input: "2024-01-01\n", wantErr: true},
+		{name: "too many commas", input: "Jan 2, 2024,Jan 5, 2024\n", wantErr: true},
+		{name: "empty start", input: ",15:17\n", wantErr: true},
+		{name: "empty end", input: "15:16:15,\n", wantErr: true},
+		{name: "blank first line with second line", input: "\n15:17:20\n", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end, err := getInput(strings.NewReader(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("getInput(%q) expected error, got start=%q end=%q", tt.input, start, end)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("getInput(%q) unexpected error: %v", tt.input, err)
+			}
+			if start != tt.start || end != tt.end {
+				t.Errorf("getInput(%q) = (%q, %q), want (%q, %q)", tt.input, start, end, tt.start, tt.end)
+			}
+		})
+	}
+}

--- a/cmd/dtmate/cmd/fmt.go
+++ b/cmd/dtmate/cmd/fmt.go
@@ -16,7 +16,7 @@ var fmtCmd = &cobra.Command{
   dtmate fmt now %s`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if optFmtList {
-			return nil
+			return cobra.NoArgs(cmd, args)
 		}
 		if len(args) != 2 {
 			return errors.New("requires two arguments: [date/time] [format specifiers]")

--- a/cmd/dtmate/cmd/root.go
+++ b/cmd/dtmate/cmd/root.go
@@ -59,8 +59,9 @@ var rootCmd = &cobra.Command{
 			os.Exit(0)
 		}
 
-		// if no arguments are provided and no flags are set, show help
-		if len(args) == 0 && !cmd.Flags().Changed("examples") && !cmd.Flags().Changed("help-all") {
+		// the flag values (not Changed) gate the branches above so that
+		// explicit --examples=false / --help-all=false still show help
+		if len(args) == 0 {
 			cmd.Help() //nolint:errcheck
 		}
 	},
@@ -96,7 +97,7 @@ func extractReadmeExamples(markdown string) string {
 	if len(matches) == 2 {
 		return matches[1]
 	}
-	return "[Internal Error] Unable to output examples. Check the extractShellCode() function."
+	return "[Internal Error] Unable to output examples. Check the extractReadmeExamples() function."
 }
 
 func ShowExamples() {


### PR DESCRIPTION
## Summary

This PR fixes six bugs found during a bug hunt focused on the dtmate CLI layer (`cmd/dtmate/cmd/`). Three of the bugs share a single root cause in the `diff -i` stdin reader, which never validated its reads and split the first line on any comma. The remaining three are smaller correctness and consistency issues in the root and fmt commands. All fixes were verified end-to-end against the built binary and the full test suite (269 tests) passes.

## Bug fixes

**diff -i mis-split comma-containing dates (silently wrong results).** Two-line stdin input such as `printf 'Jan 2, 2024\nJan 5, 2024' | dtmate diff -i` returned `-2 years 2 days 22 hours 39 minutes` instead of `3 days`, because the comma in the first line triggered pair-splitting into "Jan 2" and " 2024" even though the start and end dates were on separate lines. `getInput()` now prefers two-line mode whenever a non-empty second line exists and only comma-splits genuine single-line input.

**diff -i accepted empty stdin.** Running `dtmate diff -i` with no input printed `0 seconds` and exited 0. It now errors with a usage hint ("expected 'start,end' on one line or start and end on two lines") and exits 1.

**diff -i accepted a single line followed by EOF.** Input like `printf '2024-01-01\n' | dtmate diff -i` silently diffed the date against an empty string (parsed as "now"), producing garbage output such as `2 years 28 weeks 1 day 21 hours 40 minutes` with exit 0. This is now an error, and scanner errors are also surfaced instead of ignored.

**Explicit --examples=false or --help-all=false exited silently.** The root command's no-args branch checked `Flags().Changed()` instead of the flag values, so `dtmate --examples=false` produced no output at all. It now falls through to the help text as expected.

**Stale internal-error message.** The examples-extraction fallback message referred to `extractShellCode()`, a function that no longer exists; it now names `extractReadmeExamples()`.

**fmt -l silently ignored stray arguments.** `dtmate fmt -l bogus` listed the conversion specifiers and ignored the extra argument, while the equivalent `tz -l` rejects extra arguments. The fmt command now uses `cobra.NoArgs` when `-l` is given, matching tz.

## Implementation notes

`getInput()` was refactored to take an `io.Reader` and return an error rather than reading `os.Stdin` directly and calling `os.Exit`, making it unit-testable; the caller in the diff command handles the error and exit. Both stdin usage modes documented in the README (one comma-separated line, or start and end on two lines) continue to work unchanged.

## Testing

Added `cmd/dtmate/cmd/diff_test.go` with 14 table-driven cases for `getInput`, covering both input modes, whitespace trimming, comma-containing dates in two-line mode, trailing blank lines, and all rejected malformed inputs (empty input, missing end, too many commas, empty start or end fields). Verified `go vet ./...` is clean and `go test ./...` passes 269 tests across 4 packages. Also re-verified the previously hardened paths probed during the hunt (unknown subcommands, negative flag values, conv's manual flag parser, -A with -c on diff, wrong-direction --until, pre-1970 tz handling) still behave correctly.

## Version

Bumped `ModVersion` from 1.14.0 to 1.15.0.
