### PR TITLE
Fix 7 library parsing bugs from the v1.15.0 bug hunt; bump version to 1.16.0

### DIFF
--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -23,7 +23,7 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.15.0"
+	ModVersion string = "1.16.0"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 
@@ -121,7 +121,13 @@ var zoneOffsetRegexp = regexp.MustCompile(`[+-][0-9]{2}:?[0-9]{2}`)
 // a numeric UTC offset; fixLocalZone must leave such times alone because
 // their zone was written by the user, not stamped on by parsetime
 func sourceHasExplicitZone(source string, t time.Time) bool {
-	if name, _ := t.Zone(); name != "" && strings.Contains(source, name) {
+	name, offset := t.Zone()
+	if name != "" && strings.Contains(source, name) {
+		return true
+	}
+	// an RFC3339 trailing "Z" (e.g. "2024-01-15T08:30:00Z") denotes UTC
+	// explicitly even though the zone name "UTC" never appears in the text
+	if offset == 0 && strings.HasSuffix(source, "Z") {
 		return true
 	}
 	return zoneOffsetRegexp.MatchString(source)
@@ -172,33 +178,38 @@ func isAllDigits(s string) bool {
 }
 
 // slashDateFields splits the leading token of source into the two 1-2 digit
-// fields and 4-digit year of a slash-separated date such as "01/02/2024" or
-// "1/2/2024 08:30"; ok is false when the token does not have that shape
-func slashDateFields(source string) (first, second int, ok bool) {
+// fields and the 2 or 4 digit year of a slash-separated date such as
+// "01/02/2024", "1/2/24", or "1/2/2024 08:30"; ok is false when the token
+// does not have that shape; two-digit years must be claimed here, otherwise
+// they fall through to parsers that ignore DateOrderEnvVar and can even
+// replace the year with the current one ("12/31/24" used to parse as
+// December 31 of the current year)
+func slashDateFields(source string) (first, second, yearDigits int, ok bool) {
 	token := source
 	if i := strings.IndexAny(token, " T"); i != -1 {
 		token = token[:i]
 	}
 	parts := strings.Split(token, "/")
 	if len(parts) != 3 {
-		return 0, 0, false
+		return 0, 0, 0, false
 	}
-	if len(parts[0]) > 2 || len(parts[1]) > 2 || len(parts[2]) != 4 {
-		return 0, 0, false
+	if len(parts[0]) > 2 || len(parts[1]) > 2 || (len(parts[2]) != 4 && len(parts[2]) != 2) {
+		return 0, 0, 0, false
 	}
 	for _, part := range parts {
 		if !isAllDigits(part) {
-			return 0, 0, false
+			return 0, 0, 0, false
 		}
 	}
 	first, _ = strconv.Atoi(parts[0])
 	second, _ = strconv.Atoi(parts[1])
-	return first, second, true
+	return first, second, len(parts[2]), true
 }
 
 // slashDateTimeSuffixes are the time-of-day layouts accepted after a
-// slash-separated date; the empty suffix accepts a bare date
-var slashDateTimeSuffixes = []string{"", " 15:04:05", "T15:04:05", " 15:04", " 3:04:05PM", " 3:04PM"}
+// slash-separated date; the empty suffix accepts a bare date, and the
+// space and "T" separated forms both accept times with and without seconds
+var slashDateTimeSuffixes = []string{"", " 15:04:05", "T15:04:05", " 15:04", "T15:04", " 3:04:05PM", " 3:04PM", " 3:04:05pm", " 3:04pm"}
 
 // parseSlashDate parses slash-separated dates, whose field order the layered
 // parsers disagree on: month first (the default) or day first when
@@ -209,7 +220,7 @@ var slashDateTimeSuffixes = []string{"", " 15:04:05", "T15:04:05", " 15:04", " 3
 // caller must not try other parsers, so that no shape can silently fall
 // through to a parser with a different field order.
 func parseSlashDate(source string) (time.Time, bool, error) {
-	first, second, ok := slashDateFields(source)
+	first, second, yearDigits, ok := slashDateFields(source)
 	if !ok {
 		return time.Time{}, false, nil
 	}
@@ -235,16 +246,33 @@ func parseSlashDate(source string) (time.Time, bool, error) {
 			return time.Time{}, true, fmt.Errorf("%s must be MDY or DMY, not %q", DateOrderEnvVar, order)
 		}
 	}
-	dateLayout := "1/2/2006"
+	yearLayout := "2006"
+	if yearDigits == 2 {
+		yearLayout = "06"
+	}
+	dateLayout := "1/2/" + yearLayout
 	if !monthFirst {
-		dateLayout = "2/1/2006"
+		dateLayout = "2/1/" + yearLayout
 	}
 	for _, suffix := range slashDateTimeSuffixes {
-		if t, err := time.ParseInLocation(dateLayout+suffix, source, time.Local); err == nil {
+		t, err := time.ParseInLocation(dateLayout+suffix, source, time.Local)
+		if err == nil {
 			return t, true, nil
+		}
+		if outOfRangeParseError(err) {
+			return time.Time{}, true, fmt.Errorf("invalid date/time %q: %v", source, err)
 		}
 	}
 	return time.Time{}, true, fmt.Errorf("unable to parse date/time: %q", source)
+}
+
+// outOfRangeParseError reports whether a time.Parse error means the input
+// matched the layout's shape but a component value was invalid (e.g.
+// "2024-02-30": day out of range); such input must be rejected immediately
+// rather than falling through to lenient parsers that silently normalize
+// or even mangle it ("08:61:00" used to come back as "08:06:01")
+func outOfRangeParseError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "out of range")
 }
 
 // parseDateTime parses a date/time string: standard layouts are tried
@@ -255,12 +283,20 @@ func parseSlashDate(source string) (time.Time, bool, error) {
 // not appear in the input are rejected as corrupt rather than returned
 func parseDateTime(source string) (time.Time, error) {
 	for _, layout := range wallClockLayouts {
-		if t, err := time.ParseInLocation(layout, source, time.Local); err == nil {
+		t, err := time.ParseInLocation(layout, source, time.Local)
+		if err == nil {
 			return t, nil
+		}
+		if outOfRangeParseError(err) {
+			return time.Time{}, fmt.Errorf("invalid date/time %q: %v", source, err)
 		}
 	}
 	for _, layout := range zonedLayouts {
-		if t, err := time.Parse(layout, source); err == nil {
+		t, err := time.Parse(layout, source)
+		if outOfRangeParseError(err) {
+			return time.Time{}, fmt.Errorf("invalid date/time %q: %v", source, err)
+		}
+		if err == nil {
 			name, offset := t.Zone()
 			if offset != 0 || zeroOffsetZoneNames[strings.ToUpper(name)] {
 				return t, nil
@@ -446,9 +482,13 @@ func parseIntegerDateTime(source string, loc *time.Location) (time.Time, error) 
 // and 13-digit (milliseconds) integers as Unix timestamps; negative integers
 // are rejected because timestamps can't be negative, other integers are
 // parsed as compact date/times, and anything else is converted from a
-// relative date and parsed as a date/time
+// relative date and parsed as a date/time; empty input is rejected because
+// the lenient fallback parsers silently read it as the current time
 func parseDateTimeOrUnix(source string) (time.Time, error) {
 	source = strings.TrimSpace(source)
+	if source == "" {
+		return time.Time{}, ErrEmptyInput
+	}
 	if isPureIntegerAtoi(source) {
 		if strings.HasPrefix(source, "-") {
 			return time.Time{}, fmt.Errorf("timestamps can't be negative: %v", source)

--- a/README.md
+++ b/README.md
@@ -242,6 +242,11 @@ Use "dtmate --help-all" for duration syntax, brief units, and conversion notes.
 * * Set `DTMATE_DATE_ORDER=DMY` for day/month/year, or `MDY` to silence the
     ambiguity warning; a field greater than 12 (such as `25/12/2024`)
     disambiguates on its own.
+* * Two-digit years such as `1/2/24` follow the same order rules; years
+    69-99 are 19xx and 00-68 are 20xx.
+* **Out-of-range date/times** such as `2024-02-30` or `08:61:00` are
+  rejected instead of being silently normalized, and empty input is
+  rejected instead of being read as the current time.
 * **Pure integers** parse by digit count: 10 digits are Unix seconds, 13 are
   Unix milliseconds, while 4, 8, and 14 digits are a year (`2024`), a compact
   date (`20240101`), and a compact date/time (`20240101080102`); 11, 12, and
@@ -253,6 +258,12 @@ Use "dtmate --help-all" for duration syntax, brief units, and conversion notes.
 * **Duration amounts** must be plain decimals (`90`, `1.5`, and mid-string
   negatives such as `1 year -30 days` in `conv`); `NaN`, `Inf`, exponent
   (`1e2`), and hex (`0x1p4`) forms are rejected.
+* **Long-form unit names** are case-insensitive (`1 Hour` equals `1 hour`);
+  brief units stay case-sensitive because `D` means days while `m` means
+  minutes.
+* **Zone abbreviations** such as `CET` or `EST` always mean their fixed UTC
+  offsets, on any date; use an IANA name such as `Europe/Paris` (or a
+  `DTMATE_TZ_ALIASES` alias) for DST-aware conversion.
 * **Duration range and precision**: durations are computed in integer
   nanoseconds, so integral amounts are exact; fractional amounts carry
   float64 precision (about 15-16 significant digits); totals are limited to

--- a/dur.go
+++ b/dur.go
@@ -30,8 +30,10 @@ type OptionsDur func(*Dur)
 const (
 	// a period is a series of amount/unit pairs; the amount must start at the
 	// beginning of the string or after whitespace so that a fractional amount
-	// such as "1.5" can never be partially matched as "5"
-	expanded string = `(?:^|\s)(\d+(?:\.\d+)?)\s(years?|weeks?|days?|hours?|minutes?|seconds?|milliseconds?|microseconds?|nanoseconds?)`
+	// such as "1.5" can never be partially matched as "5"; long-form unit
+	// names are case-insensitive, matching conv and durmath (brief units stay
+	// case-sensitive because "D" means days while "m" means minutes)
+	expanded string = `(?:^|\s)(\d+(?:\.\d+)?)\s((?i:years?|weeks?|days?|hours?|minutes?|seconds?|milliseconds?|microseconds?|nanoseconds?))`
 	hintMsg  string = "Hint: duplicate durations not allowed; dates in uppercase; times in lowercase"
 
 	// maxUntilIterations is a backstop against unbounded output from the
@@ -264,7 +266,7 @@ func parsePeriod(period string) ([][2]string, error) {
 // fractional part is applied as nanoseconds
 func applyPeriod(to carbon.Carbon, periodMatches [][2]string, index int) (carbon.Carbon, error) {
 	for _, match := range periodMatches {
-		amount, word := match[0], removeTrailingS(match[1])
+		amount, word := match[0], normalizeUnit(match[1])
 		value, err := strconv.ParseFloat(amount, 64)
 		if err != nil {
 			return to, err

--- a/parsing_fix_test.go
+++ b/parsing_fix_test.go
@@ -1,0 +1,180 @@
+package DateTimeMate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTwoDigitYearSlashDates(t *testing.T) {
+	// no t.Parallel: t.Setenv is process-wide
+	// two-digit years must go through the same slash-date machinery as
+	// four-digit years; they used to fall through to parsetime, which
+	// ignored DateOrderEnvVar and replaced the year of "12/31/24" with the
+	// current year
+	t.Setenv(DateOrderEnvVar, "MDY")
+	testFormat(t, "1/2/24", "%F", "2024-01-02")
+	testFormat(t, "12/31/24", "%F", "2024-12-31")
+	testFormat(t, "31/12/24", "%F", "2024-12-31")
+	testFormat(t, "1/2/24 08:30", "%F %H:%M", "2024-01-02 08:30")
+
+	// Go's "06" layout convention: 69-99 are 19xx
+	testFormat(t, "7/4/76", "%F", "1976-07-04")
+
+	t.Setenv(DateOrderEnvVar, "DMY")
+	testFormat(t, "1/2/24", "%F", "2024-02-01")
+
+	// neither field can be a month
+	if _, err := Reformat("13/13/24", "%F"); err == nil {
+		t.Error("expected an error when neither slash-date field can be a month, got nil")
+	}
+}
+
+func TestOutOfRangeDateTimeRejected(t *testing.T) {
+	// no t.Parallel: t.Setenv is process-wide
+	// components the strict layouts reject as out of range must error
+	// instead of falling through to parsers that silently normalize
+	// ("2024-02-30" became March 1) or mangle ("08:61:00" became "08:06:01")
+	t.Setenv(DateOrderEnvVar, "MDY")
+	invalid := []string{
+		"2024-02-30",
+		"2024-04-31",
+		"2024-00-15",
+		"2024-01-15 08:61:00",
+		"2024-01-15 08:30:61",
+		"2024-01-15 25:00:00",
+		"2024-02-30T12:00:00Z",
+		"2/30/2024",
+		"1/32/2024",
+		"1/2/2024 13:04PM",
+	}
+	for _, source := range invalid {
+		if _, err := Reformat(source, "%F"); err == nil {
+			t.Errorf("expected an error for %q, got nil", source)
+		}
+	}
+
+	// valid edge values must still parse
+	testFormat(t, "2024-02-29", "%F", "2024-02-29")
+	testFormat(t, "2024-12-31 23:59:59", "%F %T", "2024-12-31 23:59:59")
+
+	// the same rejection must hold when a time zone conversion parses the
+	// wall clock
+	conv := setupConverter()
+	if _, err := conv.ConvertTimeZone("2024-02-30 12:00:00 EST", "UTC"); err == nil {
+		t.Error("expected an error for an out-of-range date in tz, got nil")
+	}
+}
+
+func TestEmptyDateTimeRejected(t *testing.T) {
+	// empty and whitespace-only date/times used to silently parse as the
+	// current time
+	for _, source := range []string{"", "   "} {
+		if _, err := Reformat(source, "%F"); err == nil {
+			t.Errorf("Reformat: expected an error for %q, got nil", source)
+		}
+	}
+	dur := NewDur(DurWithFrom(""), DurWithDur("1 hour"))
+	if _, err := dur.Add(); err == nil {
+		t.Error("Dur: expected an error for an empty From, got nil")
+	}
+	diff := NewDiff(DiffWithStart(""), DiffWithEnd("2024-01-01"))
+	if _, _, err := diff.CalculateDiff(); err == nil {
+		t.Error("Diff: expected an error for an empty Start, got nil")
+	}
+	diff = NewDiff(DiffWithStart("2024-01-01"), DiffWithEnd(" "))
+	if _, _, err := diff.CalculateDiff(); err == nil {
+		t.Error("Diff: expected an error for a blank End, got nil")
+	}
+}
+
+func TestZuluWithContradictoryZoneRejected(t *testing.T) {
+	// a trailing "Z" is an explicit UTC designator: combining it with a
+	// different trailing zone used to silently discard the Z and reinterpret
+	// the wall clock in that zone
+	conv := setupConverter()
+	for _, source := range []string{"2024-01-15T08:30:00Z EST", "2024-01-15T08:30:00.5Z EST"} {
+		_, err := conv.ConvertTimeZone(source, "UTC")
+		if err == nil {
+			t.Errorf("expected an error for %q, got nil", source)
+			continue
+		}
+		if !strings.Contains(err.Error(), "names both") {
+			t.Errorf("expected a contradictory-zone error for %q, got: %v", source, err)
+		}
+	}
+
+	// agreeing zones must still convert
+	result, err := conv.ConvertTimeZone("2024-01-15T08:30:00Z UTC", "America/New_York")
+	assert.NoError(t, err)
+	assert.Equal(t, "2024-01-15 03:30:00 EST", result.Format("2006-01-02 15:04:05 MST"))
+}
+
+func TestAbbreviationsKeepFixedOffsets(t *testing.T) {
+	// CET, EET, and WET are also IANA legacy zones with DST rules; as
+	// abbreviations they must mean their fixed table offsets on any date,
+	// otherwise "08:30 CET" on a summer date silently becomes 08:30 CEST
+	conv := setupConverter()
+	tests := []struct {
+		sourceTime string
+		expected   string
+	}{
+		{"2024-07-15 08:30:00 CET", "2024-07-15 07:30:00"},
+		{"2024-07-15 08:30:00 EET", "2024-07-15 06:30:00"},
+		{"2024-07-15 08:30:00 WET", "2024-07-15 08:30:00"},
+		{"2024-01-15 08:30:00 CET", "2024-01-15 07:30:00"},
+	}
+	for _, tt := range tests {
+		result, err := conv.ConvertTimeZone(tt.sourceTime, "UTC")
+		assert.NoError(t, err)
+		assert.Equal(t, tt.expected, result.Format("2006-01-02 15:04:05"), "source: %s", tt.sourceTime)
+	}
+
+	// full IANA names stay DST-aware
+	result, err := conv.ConvertTimeZone("2024-07-15 08:30:00 Europe/Paris", "UTC")
+	assert.NoError(t, err)
+	assert.Equal(t, "2024-07-15 06:30:00", result.Format("2006-01-02 15:04:05"))
+}
+
+func TestDurCaseInsensitiveLongUnits(t *testing.T) {
+	// conv and durmath already accept any case for long-form units; dur
+	// used to reject anything but lowercase
+	for _, period := range []string{"1 hour 30 minutes", "1 Hour 30 Minutes", "1 HOUR 30 MINUTES"} {
+		dur := NewDur(DurWithFrom("2024-01-15 08:00:00"), DurWithDur(period), DurWithOutputFormat("%F %T"))
+		add, err := dur.Add()
+		if err != nil {
+			t.Fatalf("Dur(%q): %v", period, err)
+		}
+		if len(add) != 1 || add[0] != "2024-01-15 09:30:00" {
+			t.Errorf("Dur(%q): [computed: %v] != [correct: 2024-01-15 09:30:00]", period, add)
+		}
+	}
+
+	// brief units stay case-sensitive: "D" means days while "d" is invalid
+	dur := NewDur(DurWithFrom("2024-01-15 08:00:00"), DurWithDur("1d"))
+	if _, err := dur.Add(); err == nil {
+		t.Error("expected an error for the invalid brief unit \"d\", got nil")
+	}
+	dur = NewDur(DurWithFrom("2024-01-15 08:00:00"), DurWithDur("1D"), DurWithOutputFormat("%F %T"))
+	add, err := dur.Add()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(add) != 1 || add[0] != "2024-01-16 08:00:00" {
+		t.Errorf("[computed: %v] != [correct: 2024-01-16 08:00:00]", add)
+	}
+}
+
+func TestSlashDateTimeSuffixVariants(t *testing.T) {
+	// no t.Parallel: t.Setenv is process-wide
+	// the "T" separator and lowercase am/pm are accepted alongside the
+	// space-separated and uppercase forms
+	t.Setenv(DateOrderEnvVar, "MDY")
+	testFormat(t, "1/2/2024T08:30", "%F %H:%M", "2024-01-02 08:30")
+	testFormat(t, "1/2/2024T08:30:45", "%F %T", "2024-01-02 08:30:45")
+	testFormat(t, "1/2/24T08:30", "%F %H:%M", "2024-01-02 08:30")
+	testFormat(t, "1/2/2024 3:04pm", "%F %H:%M", "2024-01-02 15:04")
+	testFormat(t, "1/2/2024 3:04:05pm", "%F %T", "2024-01-02 15:04:05")
+	testFormat(t, "1/2/2024 3:04PM", "%F %H:%M", "2024-01-02 15:04")
+}

--- a/timezone.go
+++ b/timezone.go
@@ -285,8 +285,12 @@ func isZoneName(s string) bool {
 }
 
 // resolveLocation resolves a time zone given as an aliased abbreviation,
-// an IANA name (DST aware, case-insensitive), an abbreviation from
-// ZoneAbbrevs, or a UTC offset in seconds
+// an abbreviation from ZoneAbbrevs (a fixed offset), an IANA name
+// (DST aware, case-insensitive), or a UTC offset in seconds; abbreviations
+// are checked before IANA names because CET, EET, and WET are also IANA
+// legacy zones with DST rules, which would silently turn "08:30 CET" on a
+// summer date into 08:30 CEST; every other colliding name (EST, MST, HST,
+// GMT, UTC) is a fixed IANA zone with the same offset as the table entry
 func (c *TimeZoneConverter) resolveLocation(zone string) (*time.Location, error) {
 	upper := strings.ToUpper(zone)
 	if target, ok := c.Aliases[upper]; ok {
@@ -296,11 +300,11 @@ func (c *TimeZoneConverter) resolveLocation(zone string) (*time.Location, error)
 		}
 		return loc, nil
 	}
-	if loc, err := loadIANALocation(zone); err == nil {
-		return loc, nil
-	}
 	if def, ok := c.ZoneAbbrevs[upper]; ok {
 		return time.FixedZone(upper, def.Offset), nil
+	}
+	if loc, err := loadIANALocation(zone); err == nil {
+		return loc, nil
 	}
 	offset, err := parseOffset(zone)
 	if err == nil {


### PR DESCRIPTION
## Summary

This PR fixes seven bugs found during a bug hunt focused on the DateTimeMate Go library (the CLI hunt was completed in v1.15.0). All seven produced either silently wrong results or inconsistent acceptance across the library entry points (`Reformat`, `Dur`, `Diff`, `Conv`, `DurMath`, `TimeZoneConverter`). Each fix ships with regression tests in the new `parsing_fix_test.go`, and the README parsing notes now document the corrected behavior. Version bumped to 1.16.0.

## Bug 1: Two-digit-year slash dates were silently corrupted

`slashDateFields` required a 4-digit year, so dates such as `1/2/24` bypassed the entire slash-date machinery and fell through to parsetime, which ignores `DTMATE_DATE_ORDER` and has its own field-order ideas: `12/31/24` parsed as December 31 of the *current* year (the year 24 was discarded entirely), and `1/2/24` parsed day-first even with `DTMATE_DATE_ORDER=MDY` set, with no ambiguity warning. Two-digit years are now claimed by `parseSlashDate` and follow the exact same order rules as 4-digit years, using Go's standard `06` layout convention (69-99 are 19xx, 00-68 are 20xx).

## Bug 2: Out-of-range date/time components were silently normalized or mangled

Inputs that the strict layouts correctly rejected as out of range fell through to parsetime, which silently "fixed" them: `2024-02-30` became March 1, `2024-04-31` became May 1, and worse, `08:61:00` came back as the reshuffled `08:06:01` and `08:30:61` as `08:30:06`. The same corruption was reachable through `tz` (`2024-02-30 12:00:00 EST` converted happily). A new `outOfRangeParseError` guard in `parseDateTime` and `parseSlashDate` now returns the range error (e.g. `day out of range`) the moment a layout matches the input's shape but a component value is invalid, instead of falling through to lenient parsers. Compact-integer and slash forms already errored; all shapes are now consistent.

## Bug 3: Empty input silently parsed as the current time

`Reformat("")`, a `Dur` with an empty `From`, and a `Diff` with an empty or whitespace-only side all silently produced "now", so a blank field from a script pipeline yielded plausible-looking garbage (a `diff` against an empty start returned "-2 years 5 weeks ..."). Meanwhile `ConvertTimeZone` already rejected empty input with `ErrEmptyInput`. `parseDateTimeOrUnix` now rejects empty and whitespace-only input with the same `ErrEmptyInput`, making every entry point consistent.

## Bug 4: A trailing "Z" escaped the explicit-zone check in tz

`ConvertTimeZone("2024-01-15T08:30:00Z EST", "UTC")` silently threw away the explicit Zulu designator and re-stamped the wall clock as EST, returning 13:30 UTC, while the equivalent `...T08:30:00+00:00 EST` correctly errored with "source names both UTC+00:00 and EST (UTC-05:00)". `sourceHasExplicitZone` checked for the zone name and numeric offsets in the source text, but `Z` is neither. It now treats a trailing `Z` on a zero-offset parse as an explicit UTC marker, so the contradictory form errors loudly and agreeing forms (`...Z UTC`) still convert.

## Bug 5: CET, EET, and WET sources were silently DST-shifted on summer dates

`resolveLocation` tried the IANA lookup before the `ZoneAbbrevs` table, and CET/EET/WET happen to be IANA legacy zones *with DST rules*: `2024-07-15 08:30:00 CET` was interpreted as CEST (+2), making "CET" and "CEST" mean the same instant in July, while every other abbreviation (EST, CST, JST, ...) was honored as a fixed offset year-round. The abbreviation table is now consulted before the IANA lookup, so abbreviations always mean their fixed table offsets on any date. This is safe for every other colliding name (EST, MST, HST, GMT, UTC) because those IANA legacy zones are fixed with the same offsets. Full IANA names such as `Europe/Paris` remain DST-aware, and `DTMATE_TZ_ALIASES` still pins an abbreviation to an IANA zone when DST-aware behavior is wanted.

## Bug 6: dur rejected capitalized long-form units that conv and durmath accept

`Dur` with a period of `1 Hour` or `1 HOUR` errored while `Conv` and `DurMath` accepted them, because the `dur` period regexp was case-sensitive. The long-form unit alternation is now case-insensitive (`(?i:...)`) and `applyPeriod` normalizes the matched unit with the shared `normalizeUnit`, matching the other sub-systems. Brief units remain case-sensitive by design, since `D` means days while `m` means minutes.

## Bug 7: Slash-date time suffixes had arbitrary gaps

`1/2/2024T08:30` errored while both `1/2/2024 08:30` and `1/2/2024T08:30:45` worked, and `1/2/2024 3:04pm` errored while `3:04PM` worked. Added the missing `T15:04` layout and lowercase `pm` variants to `slashDateTimeSuffixes`.

## Testing

All 276 tests pass (`go test ./...`), including 7 new regression tests covering every fix plus edge cases: two-digit-year order rules under both MDY and DMY, the 69/68 century pivot, ten out-of-range shapes with valid leap-day and end-of-year controls, empty input across `Reformat`/`Dur`/`Diff`, the Zulu contradiction with fractional seconds and an agreeing-zone control, fixed-offset abbreviations in summer and winter with a DST-aware IANA control, and case-insensitive long units with brief case-sensitivity controls. `go vet ./...` is clean, and the original bug-hunt repro harness was re-run against the fixed library to confirm each of the seven reproductions now returns either the correct value or a loud error, with previously working behavior (README examples, unix timestamps, relative dates) unchanged.
