### PR TITLE
Replace carbon arithmetic with internal/datecalc (PR 2 of dependency removal)

### DIFF
--- a/DEPENDENCY_REPLACEMENT.md
+++ b/DEPENDENCY_REPLACEMENT.md
@@ -21,8 +21,8 @@ landed.
 
 | Step | State | Notes |
 |---|---|---|
-| PR 1: durafmt -> internal/humandur | implemented | on branch `remove-deps`, awaiting commit/PR |
-| PR 2: carbon arithmetic -> internal/datecalc | not started | |
+| PR 1: durafmt -> internal/humandur | merged | PR #49, commit 425cc95 |
+| PR 2: carbon arithmetic -> internal/datecalc | implemented | on branch `remove-deps-pr2`, awaiting commit/PR |
 | PR 3: unified fallback parser (internal/dtparse) | not started | |
 | strftime | no work planned | kept as external dependency, see locked decision 3 |
 

--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -66,16 +66,16 @@ var abbrevMap = [][]string{
 func ConvertRelativeDateToActual(from string) string {
 	switch strings.ToLower(from) {
 	case "now":
-		return carbon.Now().String()
+		return time.Now().Format("2006-01-02 15:04:05")
 	case "today":
-		return carbon.Now().String()
+		return time.Now().Format("2006-01-02 15:04:05")
 	case "yesterday":
-		// SubHours keeps the documented "exactly 24 hours" promise; SubDay
+		// Add keeps the documented "exactly 24 hours" promise; AddDate
 		// is calendar-day arithmetic, which is 23 or 25 real hours on the
 		// two DST transition days
-		return carbon.Now().SubHours(24).String()
+		return time.Now().Add(-24 * time.Hour).Format("2006-01-02 15:04:05")
 	case "tomorrow":
-		return carbon.Now().AddHours(24).String()
+		return time.Now().Add(24 * time.Hour).Format("2006-01-02 15:04:05")
 	}
 	return from
 }

--- a/dur.go
+++ b/dur.go
@@ -2,7 +2,7 @@ package DateTimeMate
 
 import (
 	"fmt"
-	"github.com/golang-module/carbon/v2"
+	"github.com/jftuga/DateTimeMate/internal/datecalc"
 	"github.com/lestrrat-go/strftime"
 	"math"
 	"regexp"
@@ -41,20 +41,8 @@ const (
 	maxUntilIterations = 1_000_000
 )
 
-var carbonFuncs = map[string]interface{}{
-	"year":        [2]interface{}{carbon.Carbon.AddYears, carbon.Carbon.SubYears},
-	"week":        [2]interface{}{carbon.Carbon.AddWeeks, carbon.Carbon.SubWeeks},
-	"day":         [2]interface{}{carbon.Carbon.AddDays, carbon.Carbon.SubDays},
-	"hour":        [2]interface{}{carbon.Carbon.AddHours, carbon.Carbon.SubHours},
-	"minute":      [2]interface{}{carbon.Carbon.AddMinutes, carbon.Carbon.SubMinutes},
-	"second":      [2]interface{}{carbon.Carbon.AddSeconds, carbon.Carbon.SubSeconds},
-	"millisecond": [2]interface{}{carbon.Carbon.AddMilliseconds, carbon.Carbon.SubMilliseconds},
-	"microsecond": [2]interface{}{carbon.Carbon.AddMicroseconds, carbon.Carbon.SubMicroseconds},
-	"nanosecond":  [2]interface{}{carbon.Carbon.AddNanoseconds, carbon.Carbon.SubNanoseconds},
-}
-
 // unitNanoseconds is used to apply the fractional part of an amount, so the
-// calendar-aware carbon functions still handle the integer part
+// calendar-aware datecalc functions still handle the integer part
 var unitNanoseconds = map[string]float64{
 	"year":        365.25 * 24 * float64(time.Hour),
 	"week":        7 * 24 * float64(time.Hour),
@@ -132,20 +120,16 @@ func (dur *Dur) addOrSub(op int) ([]string, error) {
 		return nil, fmt.Errorf("repeat & until are mutually exclusive")
 	}
 
-	f, err := parseDateTimeOrUnix(dur.From)
+	from, err := parseDateTimeOrUnix(dur.From)
 	if err != nil {
 		return nil, err
-	}
-	from := carbon.CreateFromStdTime(f)
-	if from.Error != nil {
-		return nil, from.Error
 	}
 	periodMatches, err := parsePeriod(dur.Period)
 	if err != nil {
 		return nil, err
 	}
 
-	var all []carbon.Carbon
+	var all []time.Time
 	switch {
 	case dur.Repeat == 0 && dur.Until == "":
 		to, err := applyPeriod(from, periodMatches, op)
@@ -169,10 +153,10 @@ func (dur *Dur) addOrSub(op int) ([]string, error) {
 		}
 		// the until date/time must lie in the direction of travel, otherwise
 		// the loop would exit immediately with an empty result and no error
-		if opAdd == op && !u.After(f) {
+		if opAdd == op && !u.After(from) {
 			return nil, fmt.Errorf("until date/time %q is not after from %q", dur.Until, dur.From)
 		}
-		if opSub == op && !u.Before(f) {
+		if opSub == op && !u.Before(from) {
 			return nil, fmt.Errorf("until date/time %q is not before from %q", dur.Until, dur.From)
 		}
 		to := from
@@ -184,16 +168,16 @@ func (dur *Dur) addOrSub(op int) ([]string, error) {
 			if err != nil {
 				return nil, err
 			}
-			if next.StdTime().Equal(to.StdTime()) {
+			if next.Equal(to) {
 				return nil, fmt.Errorf("duration %q does not advance toward the until date/time", dur.Period)
 			}
 			to = next
 			if opAdd == op {
-				if to.StdTime().After(u) {
+				if to.After(u) {
 					break
 				}
 			} else {
-				if to.StdTime().Before(u) {
+				if to.Before(u) {
 					break
 				}
 			}
@@ -205,11 +189,11 @@ func (dur *Dur) addOrSub(op int) ([]string, error) {
 
 // renderResults converts computed date/times to strings, applying the
 // optional strftime output format which also supports the unix time %s modifier
-func (dur *Dur) renderResults(all []carbon.Carbon) ([]string, error) {
+func (dur *Dur) renderResults(all []time.Time) ([]string, error) {
 	rendered := make([]string, 0, len(all))
 	if len(dur.OutputFormat) == 0 {
-		for _, c := range all {
-			rendered = append(rendered, c.ToString())
+		for _, t := range all {
+			rendered = append(rendered, t.String())
 		}
 		return rendered, nil
 	}
@@ -217,8 +201,8 @@ func (dur *Dur) renderResults(all []carbon.Carbon) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, c := range all {
-		rendered = append(rendered, f.FormatString(c.StdTime()))
+	for _, t := range all {
+		rendered = append(rendered, f.FormatString(t))
 	}
 	return rendered, nil
 }
@@ -261,10 +245,14 @@ func parsePeriod(period string) ([][2]string, error) {
 }
 
 // applyPeriod applies each (amount, unit) pair of a parsed period to a date/time
-// when index==0, then add; when index==1, then subtract
-// the integer part of an amount uses carbon's calendar-aware functions; any
+// when op==opAdd, then add; when op==opSub, then subtract
+// the integer part of an amount uses datecalc's calendar-aware functions; any
 // fractional part is applied as nanoseconds
-func applyPeriod(to carbon.Carbon, periodMatches [][2]string, index int) (carbon.Carbon, error) {
+func applyPeriod(to time.Time, periodMatches [][2]string, op int) (time.Time, error) {
+	sign := +1
+	if op == opSub {
+		sign = -1
+	}
 	for _, match := range periodMatches {
 		amount, word := match[0], normalizeUnit(match[1])
 		value, err := strconv.ParseFloat(amount, 64)
@@ -275,13 +263,16 @@ func applyPeriod(to carbon.Carbon, periodMatches [][2]string, index int) (carbon
 			return to, fmt.Errorf("amount too large: %s", amount)
 		}
 		whole, frac := math.Modf(value)
-		to = carbonFuncs[word].([2]interface{})[index].(func(carbon.Carbon, int) carbon.Carbon)(to, int(whole))
+		to, err = datecalc.Apply(to, word, int(whole), sign)
+		if err != nil {
+			return to, err
+		}
 		if frac > 0 {
 			ns := int(math.Round(frac * unitNanoseconds[word]))
-			to = carbonFuncs["nanosecond"].([2]interface{})[index].(func(carbon.Carbon, int) carbon.Carbon)(to, ns)
-		}
-		if to.Error != nil {
-			return to, to.Error
+			to, err = datecalc.Apply(to, "nanosecond", ns, sign)
+			if err != nil {
+				return to, err
+			}
 		}
 	}
 	return to, nil

--- a/dur_test.go
+++ b/dur_test.go
@@ -1,7 +1,6 @@
 package DateTimeMate
 
 import (
-	"github.com/golang-module/carbon/v2"
 	"strings"
 	"testing"
 	"time"
@@ -471,8 +470,9 @@ func TestDurPre1970Until(t *testing.T) {
 
 func TestDurRelativeUntil(t *testing.T) {
 	t.Parallel()
-	start := carbon.Now().StartOfDay()
-	from := start.ToDateTimeString()
+	now := time.Now()
+	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+	from := start.Format("2006-01-02 15:04:05")
 	dur := NewDur(
 		DurWithFrom(from),
 		DurWithDur("7h59m1s"),
@@ -489,7 +489,7 @@ func TestDurRelativeUntil(t *testing.T) {
 	}
 	period := 7*time.Hour + 59*time.Minute + 1*time.Second
 	for i := range len(future) {
-		correct := start.StdTime().Add(time.Duration(i+1) * period).Format("2006-01-02 15:04:05")
+		correct := start.Add(time.Duration(i+1) * period).Format("2006-01-02 15:04:05")
 		if !strings.Contains(future[i], correct) {
 			t.Errorf("[from: %v] [computed: %v] does not contain: [correct: %v]", from, future[i], correct)
 		}

--- a/internal/datecalc/datecalc.go
+++ b/internal/datecalc/datecalc.go
@@ -1,0 +1,39 @@
+// Package datecalc applies a signed number of calendar or clock units to a
+// time.Time. It replaces the arithmetic portion of
+// github.com/golang-module/carbon: years, weeks, and days use the
+// calendar-aware, overflow-normalizing time.Time.AddDate (Feb 29 + 1 year =
+// Mar 1), while hours through nanoseconds use the absolute time.Time.Add.
+package datecalc
+
+import (
+	"fmt"
+	"time"
+)
+
+// clockUnits are the units applied as absolute durations via time.Time.Add.
+var clockUnits = map[string]time.Duration{
+	"hour":        time.Hour,
+	"minute":      time.Minute,
+	"second":      time.Second,
+	"millisecond": time.Millisecond,
+	"microsecond": time.Microsecond,
+	"nanosecond":  time.Nanosecond,
+}
+
+// Apply adds (sign=+1) or subtracts (sign=-1) n units to t. unit is one of:
+// year, week, day, hour, minute, second, millisecond, microsecond,
+// nanosecond (singular, lowercase).
+func Apply(t time.Time, unit string, n int, sign int) (time.Time, error) {
+	switch unit {
+	case "year":
+		return t.AddDate(sign*n, 0, 0), nil
+	case "week":
+		return t.AddDate(0, 0, sign*n*7), nil
+	case "day":
+		return t.AddDate(0, 0, sign*n), nil
+	}
+	if d, ok := clockUnits[unit]; ok {
+		return t.Add(time.Duration(sign*n) * d), nil
+	}
+	return t, fmt.Errorf("unknown unit: %q", unit)
+}

--- a/internal/datecalc/datecalc_test.go
+++ b/internal/datecalc/datecalc_test.go
@@ -1,0 +1,79 @@
+package datecalc
+
+import (
+	"testing"
+	"time"
+)
+
+func TestApply(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2024, 6, 15, 12, 30, 45, 123456789, time.UTC)
+	tests := []struct {
+		name string
+		t    time.Time
+		unit string
+		n    int
+		sign int
+		want time.Time
+	}{
+		{"add year", base, "year", 1, +1, time.Date(2025, 6, 15, 12, 30, 45, 123456789, time.UTC)},
+		{"sub year", base, "year", 2, -1, time.Date(2022, 6, 15, 12, 30, 45, 123456789, time.UTC)},
+		{"leap day plus one year normalizes to Mar 1", time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC), "year", 1, +1, time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)},
+		{"add week", base, "week", 2, +1, time.Date(2024, 6, 29, 12, 30, 45, 123456789, time.UTC)},
+		{"sub week crosses month", base, "week", 3, -1, time.Date(2024, 5, 25, 12, 30, 45, 123456789, time.UTC)},
+		{"add day", base, "day", 20, +1, time.Date(2024, 7, 5, 12, 30, 45, 123456789, time.UTC)},
+		{"sub day", base, "day", 15, -1, time.Date(2024, 5, 31, 12, 30, 45, 123456789, time.UTC)},
+		{"add hour", base, "hour", 13, +1, time.Date(2024, 6, 16, 1, 30, 45, 123456789, time.UTC)},
+		{"sub minute", base, "minute", 31, -1, time.Date(2024, 6, 15, 11, 59, 45, 123456789, time.UTC)},
+		{"add second", base, "second", 15, +1, time.Date(2024, 6, 15, 12, 31, 0, 123456789, time.UTC)},
+		{"add millisecond", base, "millisecond", 2, +1, time.Date(2024, 6, 15, 12, 30, 45, 125456789, time.UTC)},
+		{"sub microsecond", base, "microsecond", 456, -1, time.Date(2024, 6, 15, 12, 30, 45, 123000789, time.UTC)},
+		{"add nanosecond", base, "nanosecond", 211, +1, time.Date(2024, 6, 15, 12, 30, 45, 123457000, time.UTC)},
+		{"zero count is identity", base, "day", 0, +1, base},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Apply(tt.t, tt.unit, tt.n, tt.sign)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("Apply(%v, %q, %d, %d) = %v, want %v", tt.t, tt.unit, tt.n, tt.sign, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyDST(t *testing.T) {
+	t.Parallel()
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 2024-03-10 02:00 EST -> 03:00 EDT: the day is only 23 real hours
+	before := time.Date(2024, 3, 9, 12, 0, 0, 0, loc)
+	// day arithmetic is calendar-aware: same wall clock the next day
+	gotDay, err := Apply(before, "day", 1, +1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotDay.Hour() != 12 {
+		t.Errorf("adding 1 day across DST should keep the wall clock at 12, got %d", gotDay.Hour())
+	}
+	// hour arithmetic is absolute: 24 real hours lands at 13:00 EDT
+	gotHours, err := Apply(before, "hour", 24, +1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotHours.Hour() != 13 {
+		t.Errorf("adding 24 hours across DST should land at 13, got %d", gotHours.Hour())
+	}
+}
+
+func TestApplyUnknownUnit(t *testing.T) {
+	t.Parallel()
+	if _, err := Apply(time.Now(), "month", 1, +1); err == nil {
+		t.Error("expected an error for an unsupported unit, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

This is the second of three sequential PRs described in DEPENDENCY_REPLACEMENT.md that remove three of the four third-party date/time dependencies (durafmt, carbon, parsetime). PR 1 (#49) removed durafmt. This PR removes every usage of `golang-module/carbon/v2` except the single `carbon.Parse` fallback call in the parse pipeline, which PR 3 replaces with a unified internal parser. The pinned carbon v2.3.12 is a dead end regardless: upstream has since migrated to `dromara/carbon` with breaking changes.

## Changes

`internal/datecalc` is a new stdlib-only package exporting a single function, `Apply(t time.Time, unit string, n int, sign int) (time.Time, error)`. It replicates carbon's exact arithmetic split: years, weeks, and days use the calendar-aware, overflow-normalizing `time.Time.AddDate` (so Feb 29 + 1 year = Mar 1), while hours through nanoseconds use the absolute `time.Time.Add`. This split is what the DST-related tests in `dur_test.go` depend on and is preserved deliberately.

`dur.go` drops the `carbonFuncs` reflection table (`map[string]interface{}` holding method values, invoked through double type assertions) in favor of direct `datecalc.Apply` calls with an explicit sign. `addOrSub` now works on plain `time.Time` end to end, deleting the `carbon.CreateFromStdTime` wrapper, its dead `.Error` check, and all the `StdTime()` unwrapping in the until-loop comparisons. `renderResults` formats with `time.Time.String()`, which is byte-identical to carbon's `ToString()`. The fractional-amount logic (integer part through the unit, fractional part as rounded nanoseconds) is unchanged.

`ConvertRelativeDateToActual` in DateTimeMate.go now uses `time.Now().Format("2006-01-02 15:04:05")` and `Add(±24 * time.Hour)` for now/today/yesterday/tomorrow, preserving the documented behavior that yesterday and tomorrow are exactly 24 real hours away even across DST transitions. `dur_test.go` replaces its one `carbon.Now().StartOfDay()` helper call with a plain `time.Date` construction in `time.Local`.

As planned, carbon intentionally remains in go.mod for the one remaining `carbon.Parse` call, so `go mod tidy` changed nothing and the README Acknowledgements are untouched this round. The status table in DEPENDENCY_REPLACEMENT.md records PR 1 as merged and PR 2 as implemented.

## Testing

New table-driven tests in `internal/datecalc` cover all nine units, the leap-day normalization case, an unknown-unit error, and a DST test pinning the calendar-vs-absolute distinction: adding 1 day across the 2024 spring-forward keeps the wall clock while adding 24 hours shifts it. The full suite passes: `go build ./... && go vet ./... && go test ./...` is green with 312 tests across 6 packages, including the 497-line `dur` suite and the `durmath`/`conv` suites the plan calls out. The real CLI was rebuilt and run against the README `dur` and `durmath` examples; all fixed-date outputs match the README byte-for-byte, and the relative-date paths (`dur today ... -u tomorrow`, `diff yesterday tomorrow`) behave as documented.

## Risk

Low. Every removed carbon call maps 1:1 to a stdlib call, and the behavior-sensitive split between calendar and absolute arithmetic is pinned by both the existing dur suite and the new datecalc DST test.
