### PR TITLE
Fix 3 CLI bugs from the v1.18.0 bug hunt; bump version to 1.19.0

### DIFF
--- a/DEPENDENCY_REPLACEMENT.md
+++ b/DEPENDENCY_REPLACEMENT.md
@@ -23,7 +23,7 @@ landed.
 |---|---|---|
 | PR 1: durafmt -> internal/humandur | merged | PR #49, commit 425cc95 |
 | PR 2: carbon arithmetic -> internal/datecalc | merged | PR #50, commit 18eda1b |
-| PR 3: unified fallback parser (internal/dtparse) | implemented | on branch `remove-deps-pr3`, awaiting commit/PR |
+| PR 3: unified fallback parser (internal/dtparse) | merged | PR #51, commit 276d683 |
 | strftime | no work planned | kept as external dependency, see locked decision 3 |
 
 ## Locked decisions

--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -22,7 +22,7 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.18.0"
+	ModVersion string = "1.19.0"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 
@@ -193,9 +193,10 @@ func slashDateFields(source string) (first, second, yearDigits int, ok bool) {
 }
 
 // slashDateTimeSuffixes are the time-of-day layouts accepted after a
-// slash-separated date; the empty suffix accepts a bare date, and the
-// space and "T" separated forms both accept times with and without seconds
-var slashDateTimeSuffixes = []string{"", " 15:04:05", "T15:04:05", " 15:04", "T15:04", " 3:04:05PM", " 3:04PM", " 3:04:05pm", " 3:04pm"}
+// slash-separated date; the empty suffix accepts a bare date, the space and
+// "T" separated forms both accept times with and without seconds, and am/pm
+// is accepted both joined to the time and separated by a space
+var slashDateTimeSuffixes = []string{"", " 15:04:05", "T15:04:05", " 15:04", "T15:04", " 3:04:05PM", " 3:04PM", " 3:04:05pm", " 3:04pm", " 3:04:05 PM", " 3:04 PM", " 3:04:05 pm", " 3:04 pm"}
 
 // parseSlashDate parses slash-separated dates, whose field order the layered
 // parsers disagree on: month first (the default) or day first when

--- a/README.md
+++ b/README.md
@@ -245,8 +245,9 @@ Use "dtmate --help-all" for duration syntax, brief units, and conversion notes.
   `2024-01`), month-name dates (`Jan 2, 2024`, `January 2, 2024 08:30:00`,
   `2-Jan-2024 08:21:44`, ANSIC forms such as `Jan 2 15:04:05 2024` with
   optional weekday and zone), RFC822/850/1036/1123, Unix and Ruby date
-  formats, slash dates, bare times of day (`08:30`, `3:04pm`,
-  `12:34:56.1234`, interpreted as today), Unix timestamps, and the relative
+  formats, slash dates, bare times of day (`08:30`, `3:04pm`, `11:00 AM`,
+  `12:34:56.1234`, interpreted as today; am/pm may be joined to the time or
+  separated by a space), Unix timestamps, and the relative
   words `now`, `today`, `yesterday`, and `tomorrow`. Inputs outside this
   list are rejected with an error instead of being guessed at.
 * **Zone abbreviations inside date/times** (such as `EDT` in

--- a/cmd/dtmate/cmd/conv.go
+++ b/cmd/dtmate/cmd/conv.go
@@ -11,6 +11,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// these vars exist only so init can register the flags for --help output;
+// DisableFlagParsing means cobra never writes them, and the real values come
+// from parseConvArgs
 var optConvBrief bool
 var optConvDecimals int
 
@@ -32,12 +35,10 @@ var convCmd = &cobra.Command{
 		if len(positional) != 2 {
 			return fmt.Errorf("accepts 2 arg(s), received %d", len(positional))
 		}
-		optConvBrief = brief
-		optConvDecimals = decimals
 		if noNewline {
 			optRootNoNewline = true
 		}
-		outputConvDuration(positional[0], positional[1], optConvBrief, optConvDecimals)
+		outputConvDuration(positional[0], positional[1], brief, decimals)
 		return nil
 	},
 }

--- a/cmd/dtmate/cmd/diff.go
+++ b/cmd/dtmate/cmd/diff.go
@@ -54,7 +54,7 @@ var optDiffAbsolute bool
 func init() {
 	rootCmd.AddCommand(diffCmd)
 	diffCmd.Flags().BoolVarP(&optDiffBrief, "brief", "b", false, "output in brief format, such as: 1Y3W4D5h6m7s")
-	diffCmd.Flags().BoolVarP(&optDiffReadFromStdin, "stdin", "i", false, "read from STDIN instead of using -s/-e")
+	diffCmd.Flags().BoolVarP(&optDiffReadFromStdin, "stdin", "i", false, "read the start and end date/times from STDIN instead of arguments")
 	diffCmd.Flags().StringVarP(&optDiffConv, "conv", "c", "", "convert resulting duration to another group of units")
 	diffCmd.Flags().IntVarP(&optDiffDecimals, "decimals", "d", 0, "with -c: show the smallest unit with this many decimal places, rounded")
 	diffCmd.Flags().BoolVarP(&optDiffAbsolute, "absolute", "A", false, "always output an absolute (positive) duration")

--- a/cmd/dtmate/cmd/dur.go
+++ b/cmd/dtmate/cmd/dur.go
@@ -22,7 +22,6 @@ var durCmd = &cobra.Command{
 }
 
 var (
-	//optDurFrom   string
 	optDurAdd    bool
 	optDurSub    bool
 	optDurUntil  string

--- a/cmd/dtmate/cmd/tz.go
+++ b/cmd/dtmate/cmd/tz.go
@@ -88,35 +88,16 @@ func listZones() {
 		if def.Ambiguous != "" {
 			note = " [ambiguous; also: " + def.Ambiguous + "]"
 		}
-		if isDSTAwareAbbrev(abbrev) {
-			note += " [DST aware]"
-		}
 		fmt.Printf("%-6s UTC%s  %s%s\n", abbrev, DateTimeMate.FormatUTCOffset(def.Offset), def.Description, note)
 	}
 	fmt.Println()
-	fmt.Println("Abbreviations marked [DST aware] resolve as IANA zones and follow their DST")
-	fmt.Println("rules; the offset shown for them is their standard (winter) offset.")
+	fmt.Println("Abbreviations always mean the fixed offsets shown, on any date: CET on a")
+	fmt.Println("summer date stays UTC+01:00 rather than becoming CEST.")
 	fmt.Println("IANA zone names such as America/New_York or Asia/Kolkata are also supported")
 	fmt.Println("and preferred: unlike the fixed offsets above, they are DST aware.")
 	fmt.Println("List them with: dtmate tz --list-iana")
 	fmt.Printf("Override an ambiguous abbreviation with the %s environment\n", DateTimeMate.ZoneAliasesEnvVar)
 	fmt.Printf("variable, e.g. %s=\"IST=Asia/Jerusalem|CST=Asia/Shanghai\"\n", DateTimeMate.ZoneAliasesEnvVar)
-}
-
-// isDSTAwareAbbrev reports whether an abbreviation resolves as an IANA
-// zone whose UTC offset changes over the year (e.g. CET), meaning the
-// fixed offset shown in the abbreviation table only applies in winter;
-// conversions resolve IANA names before the abbreviation table, so such
-// entries are DST aware in practice
-func isDSTAwareAbbrev(abbrev string) bool {
-	loc, err := time.LoadLocation(abbrev)
-	if err != nil {
-		return false
-	}
-	year := time.Now().Year()
-	_, january := time.Date(year, time.January, 15, 12, 0, 0, 0, time.UTC).In(loc).Zone()
-	_, july := time.Date(year, time.July, 15, 12, 0, 0, 0, time.UTC).In(loc).Zone()
-	return january != july
 }
 
 // listIANAZones prints each IANA zone name with the UTC offset and

--- a/dur_test.go
+++ b/dur_test.go
@@ -249,6 +249,32 @@ func TestDurPeriodErrorQuotesInput(t *testing.T) {
 	}
 }
 
+func TestDurOverflowingClockUnitsRejected(t *testing.T) {
+	t.Parallel()
+	// hour and minute counts whose nanosecond total exceeds int64 used to
+	// wrap silently ("3000000 hours" moved the date back to 1781)
+	for _, period := range []string{"3000000 hours", "200000000 minutes"} {
+		dur := NewDur(DurWithFrom("2024-01-01"), DurWithDur(period))
+		if _, err := dur.Add(); err == nil {
+			t.Errorf("expected an overflow error for %q, got nil", period)
+		}
+		if _, err := dur.Sub(); err == nil {
+			t.Errorf("expected an overflow error subtracting %q, got nil", period)
+		}
+	}
+	// a large but representable count still works
+	dur := NewDur(DurWithFrom("2024-01-01 00:00:00"), DurWithDur("2000000 hours"))
+	add, err := dur.Add()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// the exact hour depends on the local zone's offsets, but the date is
+	// stable and a silent wrap would land centuries away
+	if len(add) != 1 || !strings.HasPrefix(add[0], "2252-02-28") {
+		t.Errorf("[computed: %v] != [correct: 2252-02-28 ...]", add)
+	}
+}
+
 func TestDurZeroPeriodUntil(t *testing.T) {
 	t.Parallel()
 	// a period that does not advance must error instead of looping forever

--- a/internal/datecalc/datecalc.go
+++ b/internal/datecalc/datecalc.go
@@ -7,6 +7,7 @@ package datecalc
 
 import (
 	"fmt"
+	"math"
 	"time"
 )
 
@@ -33,6 +34,12 @@ func Apply(t time.Time, unit string, n int, sign int) (time.Time, error) {
 		return t.AddDate(0, 0, sign*n), nil
 	}
 	if d, ok := clockUnits[unit]; ok {
+		// the multiplication below is int64 nanoseconds, which silently
+		// wraps for large counts of the bigger units (about 2.56 million
+		// hours); reject anything that cannot be represented
+		if limit := math.MaxInt64 / int64(d); int64(n) > limit || int64(n) < -limit {
+			return t, fmt.Errorf("%d %ss exceeds the supported range of about 292 years", n, unit)
+		}
 		return t.Add(time.Duration(sign*n) * d), nil
 	}
 	return t, fmt.Errorf("unknown unit: %q", unit)

--- a/internal/datecalc/datecalc_test.go
+++ b/internal/datecalc/datecalc_test.go
@@ -1,6 +1,7 @@
 package datecalc
 
 import (
+	"math"
 	"testing"
 	"time"
 )
@@ -68,6 +69,36 @@ func TestApplyDST(t *testing.T) {
 	}
 	if gotHours.Hour() != 13 {
 		t.Errorf("adding 24 hours across DST should land at 13, got %d", gotHours.Hour())
+	}
+}
+
+func TestApplyOverflowRejected(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	// counts whose nanosecond total exceeds int64 used to wrap silently
+	// (3,000,000 hours moved the date backward to 1781)
+	for _, tt := range []struct {
+		unit string
+		n    int
+	}{
+		{"hour", 3_000_000},
+		{"minute", 200_000_000},
+	} {
+		if _, err := Apply(base, tt.unit, tt.n, +1); err == nil {
+			t.Errorf("Apply(%d %ss): expected an overflow error, got nil", tt.n, tt.unit)
+		}
+		if _, err := Apply(base, tt.unit, tt.n, -1); err == nil {
+			t.Errorf("Apply(-%d %ss): expected an overflow error, got nil", tt.n, tt.unit)
+		}
+	}
+	// the largest representable hour count still works
+	limit := int(int64(math.MaxInt64) / int64(time.Hour))
+	got, err := Apply(base, "hour", limit, +1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.After(base) {
+		t.Errorf("Apply(%d hours) = %v, expected a time after %v", limit, got, base)
 	}
 }
 

--- a/internal/dtparse/dtparse.go
+++ b/internal/dtparse/dtparse.go
@@ -72,9 +72,17 @@ var layouts = []layoutEntry{
 	// month name and then fails on the remainder
 	{"January 2, 2006 15:04:05", KindWallClock},
 	{"January 2, 2006 15:04", KindWallClock},
+	{"January 2, 2006 3:04:05 PM", KindWallClock},
+	{"January 2, 2006 3:04:05 pm", KindWallClock},
+	{"January 2, 2006 3:04 PM", KindWallClock},
+	{"January 2, 2006 3:04 pm", KindWallClock},
 	{"January 2, 2006", KindWallClock},
 	{"Jan 2, 2006 15:04:05", KindWallClock},
 	{"Jan 2, 2006 15:04", KindWallClock},
+	{"Jan 2, 2006 3:04:05 PM", KindWallClock},
+	{"Jan 2, 2006 3:04:05 pm", KindWallClock},
+	{"Jan 2, 2006 3:04 PM", KindWallClock},
+	{"Jan 2, 2006 3:04 pm", KindWallClock},
 	{"Jan 2, 2006", KindWallClock},
 	{"Mon, Jan 2, 2006 3:04 PM", KindWallClock},
 	// day-first month-name dates; strftime's %v renders this shape
@@ -107,13 +115,18 @@ var layouts = []layoutEntry{
 	// bare times of day, stamped with today's date after parsing; Go's "PM"
 	// element matches only uppercase and "pm" only lowercase, so both
 	// spellings need a layout (same reason slashDateTimeSuffixes in the
-	// root package carries both)
+	// root package carries both), and am/pm is accepted both joined to the
+	// time and separated by a space
 	{"15:04:05", KindTimeOnly},
 	{"15:04", KindTimeOnly},
 	{"3:04:05PM", KindTimeOnly},
 	{"3:04PM", KindTimeOnly},
 	{"3:04:05pm", KindTimeOnly},
 	{"3:04pm", KindTimeOnly},
+	{"3:04:05 PM", KindTimeOnly},
+	{"3:04 PM", KindTimeOnly},
+	{"3:04:05 pm", KindTimeOnly},
+	{"3:04 pm", KindTimeOnly},
 }
 
 // outOfRange reports whether a time.Parse error means the input matched the

--- a/internal/dtparse/dtparse_test.go
+++ b/internal/dtparse/dtparse_test.go
@@ -47,6 +47,10 @@ func TestParseMonthNameDates(t *testing.T) {
 	testParseWallClock(t, "January 2, 2024", "2024-01-02 00:00:00")
 	testParseWallClock(t, "January 2, 2024 08:30:00", "2024-01-02 08:30:00")
 	testParseWallClock(t, "Tue, Jan 2, 2024 3:04 PM", "2024-01-02 15:04:00")
+	testParseWallClock(t, "Jan 2, 2024 3:04 PM", "2024-01-02 15:04:00")
+	testParseWallClock(t, "Jan 2, 2024 3:04:05 pm", "2024-01-02 15:04:05")
+	testParseWallClock(t, "January 2, 2024 3:04:05 PM", "2024-01-02 15:04:05")
+	testParseWallClock(t, "January 2, 2024 3:04 pm", "2024-01-02 15:04:00")
 	testParseWallClock(t, "2-Jan-2024", "2024-01-02 00:00:00")
 	testParseWallClock(t, "22-Jul-2024 08:21:44", "2024-07-22 08:21:44")
 	testParseWallClock(t, "22-Jul-2024 08:21", "2024-07-22 08:21:00")
@@ -76,6 +80,9 @@ func TestParseTimeOnlyStamping(t *testing.T) {
 		"11:00PM":       "23:00:00",
 		"3:04pm":        "15:04:00",
 		"3:04:05PM":     "15:04:05",
+		"11:00 AM":      "11:00:00",
+		"3:04 pm":       "15:04:00",
+		"3:04:05 PM":    "15:04:05",
 		"12:34:56.1234": "12:34:56.1234",
 	} {
 		parsed, kind, err := Parse(source, loc)
@@ -145,7 +152,7 @@ func TestParseOutOfRangeRejected(t *testing.T) {
 	t.Parallel()
 	// a layout-shaped input with an invalid component errors immediately
 	// instead of trying later layouts
-	for _, source := range []string{"2024-13-01", "2024.02.30", "2024-1-32", "25:00", "08:61", "13:04PM", "Jan 32, 2024"} {
+	for _, source := range []string{"2024-13-01", "2024.02.30", "2024-1-32", "25:00", "08:61", "13:04PM", "13:04 PM", "Jan 32, 2024"} {
 		if _, _, err := Parse(source, time.UTC); err == nil {
 			t.Errorf("Parse(%q): expected an out-of-range error, got nil", source)
 		}

--- a/parsing_fix_test.go
+++ b/parsing_fix_test.go
@@ -48,6 +48,7 @@ func TestOutOfRangeDateTimeRejected(t *testing.T) {
 		"2/30/2024",
 		"1/32/2024",
 		"1/2/2024 13:04PM",
+		"1/2/2024 13:04 PM",
 	}
 	for _, source := range invalid {
 		if _, err := Reformat(source, "%F"); err == nil {
@@ -177,4 +178,22 @@ func TestSlashDateTimeSuffixVariants(t *testing.T) {
 	testFormat(t, "1/2/2024 3:04pm", "%F %H:%M", "2024-01-02 15:04")
 	testFormat(t, "1/2/2024 3:04:05pm", "%F %T", "2024-01-02 15:04:05")
 	testFormat(t, "1/2/2024 3:04PM", "%F %H:%M", "2024-01-02 15:04")
+	testFormat(t, "1/2/2024 3:04 PM", "%F %H:%M", "2024-01-02 15:04")
+	testFormat(t, "1/2/2024 3:04:05 pm", "%F %T", "2024-01-02 15:04:05")
+}
+
+func TestSpacedAmPmParsing(t *testing.T) {
+	// a space before am/pm parses the same as the joined form, in bare
+	// times and month-name dates alike (regression from the parsetime
+	// removal: its US format allowed whitespace before the meridiem)
+	testFormat(t, "Jan 2, 2024 3:04 PM", "%F %H:%M", "2024-01-02 15:04")
+	testFormat(t, "January 2, 2024 3:04:05 pm", "%F %T", "2024-01-02 15:04:05")
+	diff := NewDiff(DiffWithStart("11:00 AM"), DiffWithEnd("11:00PM"))
+	result, _, err := diff.CalculateDiff()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "12 hours" {
+		t.Errorf("[computed: %v] != [correct: 12 hours]", result)
+	}
 }


### PR DESCRIPTION
## Summary

This PR closes out a bug hunt over the dtmate CLI following the dependency-removal effort (PRs #49-#51). It fixes three bugs — a silent int64 overflow in duration arithmetic, misleading DST text in `tz --list-zones`, and a parsing regression for am/pm separated from the time by a space — and clears out stale cruft left behind by earlier refactors. All 324 tests pass, `go vet` is clean, and every README command-line example was verified against the fixed binary.

## Bug 1: silent date corruption on large hour and minute durations

`dtmate dur "2024-01-01 00:00:00" "3000000 hours" -a` returned `1781-09-07` — adding hours moved the date backward 243 years. The nanosecond multiplication in `internal/datecalc` (`time.Duration(n) * time.Hour`) wraps int64 for counts above about 2.56 million hours, and the existing `MaxInt32` guard in `dur.go` is far too loose to catch it (minutes overflow past ~154 million). The carbon library this code replaced had the same overflow, so the bug predates the rewrite. `datecalc.Apply` now rejects any clock-unit count whose nanosecond total cannot be represented, using the same "exceeds the supported range of about 292 years" wording as `conv`. New tests: `TestApplyOverflowRejected` (datecalc) and `TestDurOverflowingClockUnitsRejected` (root), including a boundary case proving the largest representable count still works.

## Bug 2: tz --list-zones described the opposite of actual behavior

The listing marked CET, EET, and WET as `[DST aware]` and its footer claimed "conversions resolve IANA names before the abbreviation table." That was true when PR #46 wrote it, but PR #48 deliberately flipped `resolveLocation` to check abbreviations first — precisely so `08:30 CET` on a summer date stays CET instead of silently becoming CEST — and updated the README to match, leaving this CLI text stale and contradicting both the code and the docs. The `isDSTAwareAbbrev` helper and marker are removed, and the footer now states that abbreviations always mean the fixed offsets shown, with IANA names remaining the DST-aware option.

## Bug 3: spaced am/pm no longer parsed (regression from PR #51)

`"11:00 AM"`, `"3:04:05 PM"`, `"Jan 2, 2024 3:04 PM"`, and `"1/2/2024 3:04 PM"` were all rejected. parsetime's US format allowed whitespace before the meridiem, and the PR #51 layout table only kept the joined forms — inconsistently, since it did accept the spaced form when a weekday was present (`Mon, Jan 2, 2006 3:04 PM`). Spaced uppercase and lowercase am/pm layouts are added to the dtparse table for bare times and month-name dates, and to `slashDateTimeSuffixes` for slash dates. Out-of-range forms such as `"13:04 PM"` are still rejected, and rarer parsetime shapes (no-space month-name PM, PM-with-zone) remain deliberately unsupported. The README parsing notes now document the spaced form. New tests: `TestSpacedAmPmParsing` plus dtparse and slash-suffix table additions.

## Cleanups

The `diff --stdin` help text referenced `-s/-e` flags that were removed when start and end became positional arguments. The commented-out `optDurFrom` variable in cmd/dur.go is deleted. The conv command no longer reassigns its registration-only globals in RunE, and a comment now explains that those flag variables exist solely so `--help` displays the flags under `DisableFlagParsing`. The status table in DEPENDENCY_REPLACEMENT.md is updated to show PR 3 as merged (PR #51).

## Verification

`go build ./... && go vet ./... && go test ./...` — 324 tests pass. The rebuilt binary was exercised directly: overflow inputs now error with exit 1, spaced am/pm inputs parse in fmt, diff, dur, and slash-date paths, `tz --list-zones` output matches documented behavior, and all 68 README command-line examples produce their documented output.
