### PR TITLE
Add strftime output formatting to tz via new FormatTime; bump version to 1.21.0

### DIFF
--- a/DateTimeMate.go
+++ b/DateTimeMate.go
@@ -22,7 +22,7 @@ var ReadmeMd string
 
 const (
 	ModName    string = "DateTimeMate"
-	ModVersion string = "1.20.0"
+	ModVersion string = "1.21.0"
 	ModUrl     string = "https://github.com/jftuga/DateTimeMate"
 )
 
@@ -357,17 +357,24 @@ func parseDateTimeIn(source string, loc *time.Location) (time.Time, error) {
 //   - The source date cannot be parsed
 //   - The time parser initialization fails
 func Reformat(source string, outputFormat string) (string, error) {
-	source = strings.TrimSpace(source)
+	t, err := parseDateTimeOrUnix(strings.TrimSpace(source))
+	if err != nil {
+		return "", err
+	}
+	return FormatTime(t, outputFormat)
+}
 
+// FormatTime renders an already-parsed time.Time using strftime format
+// specifiers, with additional support for Unix seconds via '%s'. Unlike
+// Reformat it performs no parsing, so the time's location (and therefore
+// %Z, %z and %s) is preserved exactly.
+//
+// Returns an error if the outputFormat is invalid.
+func FormatTime(t time.Time, outputFormat string) (string, error) {
 	// creates a new Strftime instance
 	// outputFormat is a pattern string that follows strftime formatting
 	// the additional formatting behavior allows this to also use the unix time %s modifier
 	f, err := strftime.New(outputFormat, strftime.WithUnixSeconds('s'))
-	if err != nil {
-		return "", err
-	}
-
-	t, err := parseDateTimeOrUnix(source)
 	if err != nil {
 		return "", err
 	}

--- a/DateTimeMate_test.go
+++ b/DateTimeMate_test.go
@@ -42,6 +42,36 @@ func TestReformatIntegerDate(t *testing.T) {
 	testFormat(t, "20240101080102", "%F %T", "2024-01-01 08:01:02")
 }
 
+func TestFormatTimePreservesZone(t *testing.T) {
+	// FormatTime must render in the time's own location: %Z, %z and %s all
+	// reflect the non-local zone instead of being reinterpreted locally
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := time.Date(2024, 1, 15, 7, 0, 0, 0, loc)
+	for format, correct := range map[string]string{
+		"%Y-%m-%d %H:%M:%S %Z": "2024-01-15 07:00:00 EST",
+		"%z":                   "-0500",
+		"%s":                   strconv.FormatInt(src.Unix(), 10),
+	} {
+		computed, err := FormatTime(src, format)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if computed != correct {
+			t.Errorf("[computed: %v] != [correct: %v]", computed, correct)
+		}
+	}
+}
+
+func TestFormatTimeInvalidFormat(t *testing.T) {
+	// a dangling % is an invalid strftime pattern and must error
+	if _, err := FormatTime(time.Now(), "%Y-%m-%d %"); err == nil {
+		t.Error("expected an error for an invalid format, got nil")
+	}
+}
+
 func TestNegativeTimestampRejected(t *testing.T) {
 	// negative integers are rejected everywhere as negative timestamps
 	for _, source := range []string{"-170000000", "-1700265600", "-17000000000"} {

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The command-line program, `dtmate` *(along with the golang package)* allows you 
 * * UTC offsets in seconds, such as `19800` for UTC+5:30
 * the source may also be a unix timestamp in seconds or milliseconds, such as `1700265600`
 * pin ambiguous abbreviations with an environment variable: `DTMATE_TZ_ALIASES="IST=Asia/Jerusalem|CST=Asia/Shanghai"`
+* reformat the result with strftime specifiers: `dtmate tz "2024-01-15 12:00:00 UTC" America/New_York --format "%Y-%m-%d %I:%M %p %Z"`
+* * output: `2024-01-15 07:00 AM EST`
 * list all supported abbreviations: `dtmate tz --list-zones`
 * list all IANA zone names with their current offsets: `dtmate tz --list-iana`
 </details>
@@ -570,6 +572,10 @@ $ dtmate tz "1700265600" UTC
 # a UTC offset in seconds is also accepted (19800 = UTC+5:30)
 $ dtmate tz "2024-01-15 12:00:00 UTC" 19800
 2024-01-15 17:30:00 +0530 UTC+05:30
+
+# reformat the converted result with strftime specifiers
+$ dtmate tz "2024-01-15 12:00:00 UTC" America/New_York --format "%Y-%m-%d %I:%M %p %Z"
+2024-01-15 07:00 AM EST
 
 # ambiguous abbreviations warn on stderr and use their primary meaning
 $ dtmate tz "2024-01-15 12:00:00 UTC" IST

--- a/cmd/dtmate/cmd/tz.go
+++ b/cmd/dtmate/cmd/tz.go
@@ -15,6 +15,7 @@ import (
 var optTzListZones bool
 var optTzListIANA bool
 var optTzForce bool
+var optTzFormat string
 
 var tzCmd = &cobra.Command{
 	Use:   "tz [date/time] [target time zone]",
@@ -43,6 +44,7 @@ func init() {
 	tzCmd.Flags().BoolVarP(&optTzListZones, "list-zones", "l", false, "list the supported time zone abbreviations and exit")
 	tzCmd.Flags().BoolVarP(&optTzListIANA, "list-iana", "I", false, "list the IANA time zone names (e.g. America/New_York) and exit")
 	tzCmd.Flags().BoolVarP(&optTzForce, "force", "f", false, "convert date/times before 1970 despite unreliable time zone data")
+	tzCmd.Flags().StringVar(&optTzFormat, "format", "", "output results with strftime formatting")
 	tzCmd.MarkFlagsMutuallyExclusive("list-zones", "list-iana")
 }
 
@@ -73,6 +75,13 @@ func outputTzConversion(source, target string) {
 		fmt.Fprintln(os.Stderr, "warning:", warning)
 	}
 	formatted := result.Format("2006-01-02 15:04:05 -0700 MST")
+	if optTzFormat != "" {
+		formatted, err = DateTimeMate.FormatTime(result, optTzFormat)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
 	if optRootNoNewline {
 		fmt.Print(formatted)
 	} else {


### PR DESCRIPTION
# Add strftime output formatting to tz via new FormatTime; bump version to 1.21.0

## Summary

The tz command previously emitted only the fixed `2006-01-02 15:04:05 -0700 MST` layout. This PR adds a public `FormatTime(t time.Time, outputFormat string)` library function that renders an already-parsed `time.Time` using strftime specifiers (including the `%s` Unix-seconds extension), and a `--format` flag on `dtmate tz` that uses it. The flag is long-only because `-f` is already taken by `--force` on tz; the name matches dur's `--format` for parity.

## Why a new function instead of Reformat

`Reformat` only accepts a string source, and round-tripping a converted time through a string is unsafe: Go assigns a zero offset to time zone abbreviations outside the local zone, which corrupts `%z` and `%s`. `FormatTime` performs no parsing, so the time's location is preserved exactly. `Reformat` is now implemented as parse-then-`FormatTime`, removing the duplicated strftime setup (behavior unchanged).

## Changes

`DateTimeMate.go`: new `FormatTime`; `Reformat` refactored to reuse it; `ModVersion` bumped to `1.21.0`.

`cmd/dtmate/cmd/tz.go`: `--format` flag applied after conversion; invalid formats error to stderr with exit 1 like the existing error paths; default output is unchanged when the flag is absent.

`DateTimeMate_test.go`: `TestFormatTimePreservesZone` verifies `%Z` renders `EST`, `%z` renders `-0500`, and `%s` matches the UTC instant for a time in `America/New_York`; `TestFormatTimeInvalidFormat` verifies a dangling `%` errors.

`README.md`: new tz summary bullet and examples-block entry; the examples block is embedded and feeds `dtmate -e`, verified to extract cleanly.

## Testing

`go vet ./...` clean; full suite passes (334 tests in 7 packages). Manual checks: `dtmate tz "2024-01-15 12:00:00 UTC" America/New_York --format "%Y-%m-%d %I:%M %p %Z"` yields `2024-01-15 07:00 AM EST`; `--format "%z %s"` yields `-0500 1705320000`; omitting the flag yields the unchanged `2024-01-15 07:00:00 -0500 EST`.

## Downstream

This release unblocks the datetimemate.com tz panel's new optional "Output format" field, which calls `FormatTime` from the Lambda backend.
